### PR TITLE
Fix client.SendReq to return error details from zedcloud response

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,13 +6,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/zededa/zedcloud-api/swagger_models"
 	"golang.org/x/net/publicsuffix"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/cookiejar"
 	"time"
-	"github.com/zededa/zedcloud-api/swagger_models"
 
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
@@ -57,18 +57,18 @@ func UrlForObjectRequest(urlExtension, name, id, reqType string) string {
 		return ""
 	}
 	url = fmt.Sprintf("%s/%s", urlExtension, url)
-    switch reqType {
-    case "config", "update", "delete":
-        return url
-    case "status":
-        return url + "/status"
-    case "publish":
-        return url + "/publish"
-    case "apply":
-        return url + "/apply"
-    default:
-        panic("UrlForObjectRequest - Invalid reqType: " + reqType)
-    }
+	switch reqType {
+	case "config", "update", "delete":
+		return url
+	case "status":
+		return url + "/status"
+	case "publish":
+		return url + "/publish"
+	case "apply":
+		return url + "/apply"
+	default:
+		panic("UrlForObjectRequest - Invalid reqType: " + reqType)
+	}
 }
 
 func reqBodyReaderForData(data interface{}) *bytes.Buffer {
@@ -253,6 +253,7 @@ func (client *Client) GetObj(typeUrl, name, id string,
 	if status {
 		url += "/status"
 	}
+	client.XRequestIdPrefix = "TF-GetObj"
 	_, err = client.SendReq("GET", url, nil, rspBody)
 	return err
 }


### PR DESCRIPTION
    Added support to return details of error in zedcloud response to the
    error returned by client.SendReq method.

Testing Done:

Manually verified the returned error shows up in terraform apply failure messages:

zedcloud_network_instance.<snip> : Creating...
╷
│ Error: [ERROR] NetworkInstance xxx ( id: ) Create Failed. Request FAILED. StatusCode: 409 Conflict
│ ErrorCode: AlreadyExists, Details: Entry already exists
│ 
│ 
│   with zedcloud_network_instance.xxx,
│   on demo.tf line 71, in resource "zedcloud_network_instance" "xxx:
│   71: resource "zedcloud_network_instance" "xxx" {
│ 
╵
