### PR TITLE
Fix UrlForObjectRequest to handle all action types 

### DIFF
--- a/client.go
+++ b/client.go
@@ -246,7 +246,7 @@ func (client *Client) SendReq(method, urlExtension string,
 	if err != nil {
 		return nil, err
 	}
-	client.logDebug("%s %s", method, req.URL)
+	client.logDebug("SendReq: %s %s %s", method, urlExtension, req.URL)
 	resp, err := client.HttpClient.Do(req)
 	if err != nil {
 		return resp, err
@@ -322,13 +322,31 @@ func (client *Client) GetObj(typeUrl, name, id string,
 	return err
 }
 
+func sanitizeZedcloudUrl(zedcloudUrl string) string {
+    // URL needs to be of the form:
+    //  https://<url>/api/v1/
+    //  For Ex: https://zedcontrol.zededa.net/api/v1/
+	if !strings.HasPrefix(zedcloudUrl, "https://") {
+		zedcloudUrl = "https://" + zedcloudUrl
+	}
+	// URL needs to end with a /
+	if !strings.HasSuffix(zedcloudUrl, "/") {
+		zedcloudUrl = zedcloudUrl + "/"
+	}
+	if !strings.HasSuffix(zedcloudUrl, "api/v1/") {
+		zedcloudUrl = zedcloudUrl + "api/v1/"
+	}
+	return zedcloudUrl
+}
+
+
 func NewClient(zedcloudUrl string, token, username, password string) (*Client, error) {
 	log.Println("[INFO] NewClient")
 	// create the transport
 	schemes := []string{"https"}
 	client := &Client{
 		HttpClient:       &http.Client{},
-		BaseUrl:          zedcloudUrl + "/api/v1/",
+		BaseUrl:          sanitizeZedcloudUrl(zedcloudUrl),
 		XRequestIdPrefix: "zedcloudapi-client",
 		Debug:            true,
 	}

--- a/client.go
+++ b/client.go
@@ -60,16 +60,8 @@ func UrlForObjectRequest(urlExtension, name, id, reqType string) string {
 	switch reqType {
 	case "config", "update", "delete":
 		return url
-	case "status":
-		return url + "/status"
-	case "publish":
-		return url + "/publish"
-	case "apply":
-		return url + "/apply"
-	case "uplink":
-		return url + "/uplink"
 	default:
-		panic("UrlForObjectRequest - Invalid reqType: " + reqType)
+		return url + "/" + reqType
 	}
 }
 

--- a/swagger_models/a_a_a_failure_response.go
+++ b/swagger_models/a_a_a_failure_response.go
@@ -97,6 +97,8 @@ func (m *AAAFailureResponse) validateCredential(formats strfmt.Registry) error {
 		if err := m.Credential.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("credential")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("credential")
 			}
 			return err
 		}
@@ -114,6 +116,8 @@ func (m *AAAFailureResponse) validateDetails(formats strfmt.Registry) error {
 		if err := m.Details.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("details")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("details")
 			}
 			return err
 		}
@@ -131,6 +135,8 @@ func (m *AAAFailureResponse) validateGenerateToken(formats strfmt.Registry) erro
 		if err := m.GenerateToken.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("generateToken")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("generateToken")
 			}
 			return err
 		}
@@ -148,6 +154,8 @@ func (m *AAAFailureResponse) validateLogin(formats strfmt.Registry) error {
 		if err := m.Login.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("login")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("login")
 			}
 			return err
 		}
@@ -165,6 +173,8 @@ func (m *AAAFailureResponse) validateLogout(formats strfmt.Registry) error {
 		if err := m.Logout.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("logout")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("logout")
 			}
 			return err
 		}
@@ -182,6 +192,8 @@ func (m *AAAFailureResponse) validateQuerySessionDetails(formats strfmt.Registry
 		if err := m.QuerySessionDetails.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("querySessionDetails")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("querySessionDetails")
 			}
 			return err
 		}
@@ -199,6 +211,8 @@ func (m *AAAFailureResponse) validateRefresh(formats strfmt.Registry) error {
 		if err := m.Refresh.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("refresh")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("refresh")
 			}
 			return err
 		}
@@ -216,6 +230,8 @@ func (m *AAAFailureResponse) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -272,6 +288,8 @@ func (m *AAAFailureResponse) contextValidateCredential(ctx context.Context, form
 		if err := m.Credential.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("credential")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("credential")
 			}
 			return err
 		}
@@ -286,6 +304,8 @@ func (m *AAAFailureResponse) contextValidateDetails(ctx context.Context, formats
 		if err := m.Details.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("details")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("details")
 			}
 			return err
 		}
@@ -300,6 +320,8 @@ func (m *AAAFailureResponse) contextValidateGenerateToken(ctx context.Context, f
 		if err := m.GenerateToken.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("generateToken")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("generateToken")
 			}
 			return err
 		}
@@ -314,6 +336,8 @@ func (m *AAAFailureResponse) contextValidateLogin(ctx context.Context, formats s
 		if err := m.Login.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("login")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("login")
 			}
 			return err
 		}
@@ -328,6 +352,8 @@ func (m *AAAFailureResponse) contextValidateLogout(ctx context.Context, formats 
 		if err := m.Logout.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("logout")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("logout")
 			}
 			return err
 		}
@@ -342,6 +368,8 @@ func (m *AAAFailureResponse) contextValidateQuerySessionDetails(ctx context.Cont
 		if err := m.QuerySessionDetails.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("querySessionDetails")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("querySessionDetails")
 			}
 			return err
 		}
@@ -356,6 +384,8 @@ func (m *AAAFailureResponse) contextValidateRefresh(ctx context.Context, formats
 		if err := m.Refresh.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("refresh")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("refresh")
 			}
 			return err
 		}
@@ -370,6 +400,8 @@ func (m *AAAFailureResponse) contextValidateType(ctx context.Context, formats st
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_failure_response_credential_change.go
+++ b/swagger_models/a_a_a_failure_response_credential_change.go
@@ -48,6 +48,8 @@ func (m *AAAFailureResponseCredentialChange) validateCause(formats strfmt.Regist
 		if err := m.Cause.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -76,6 +78,8 @@ func (m *AAAFailureResponseCredentialChange) contextValidateCause(ctx context.Co
 		if err := m.Cause.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_failure_response_credential_change_cause.go
+++ b/swagger_models/a_a_a_failure_response_credential_change_cause.go
@@ -23,8 +23,12 @@ import (
 type AAAFailureResponseCredentialChangeCause string
 
 func NewAAAFailureResponseCredentialChangeCause(value AAAFailureResponseCredentialChangeCause) *AAAFailureResponseCredentialChangeCause {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAAFailureResponseCredentialChangeCause.
+func (m AAAFailureResponseCredentialChangeCause) Pointer() *AAAFailureResponseCredentialChangeCause {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_failure_response_generate_token.go
+++ b/swagger_models/a_a_a_failure_response_generate_token.go
@@ -51,6 +51,8 @@ func (m *AAAFailureResponseGenerateToken) validateCause(formats strfmt.Registry)
 		if err := m.Cause.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -79,6 +81,8 @@ func (m *AAAFailureResponseGenerateToken) contextValidateCause(ctx context.Conte
 		if err := m.Cause.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_failure_response_generate_token_cause.go
+++ b/swagger_models/a_a_a_failure_response_generate_token_cause.go
@@ -23,8 +23,12 @@ import (
 type AAAFailureResponseGenerateTokenCause string
 
 func NewAAAFailureResponseGenerateTokenCause(value AAAFailureResponseGenerateTokenCause) *AAAFailureResponseGenerateTokenCause {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAAFailureResponseGenerateTokenCause.
+func (m AAAFailureResponseGenerateTokenCause) Pointer() *AAAFailureResponseGenerateTokenCause {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_failure_response_login.go
+++ b/swagger_models/a_a_a_failure_response_login.go
@@ -54,6 +54,8 @@ func (m *AAAFailureResponseLogin) validateCause(formats strfmt.Registry) error {
 		if err := m.Cause.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -82,6 +84,8 @@ func (m *AAAFailureResponseLogin) contextValidateCause(ctx context.Context, form
 		if err := m.Cause.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_failure_response_login_cause.go
+++ b/swagger_models/a_a_a_failure_response_login_cause.go
@@ -23,8 +23,12 @@ import (
 type AAAFailureResponseLoginCause string
 
 func NewAAAFailureResponseLoginCause(value AAAFailureResponseLoginCause) *AAAFailureResponseLoginCause {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAAFailureResponseLoginCause.
+func (m AAAFailureResponseLoginCause) Pointer() *AAAFailureResponseLoginCause {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_failure_response_logout.go
+++ b/swagger_models/a_a_a_failure_response_logout.go
@@ -58,6 +58,8 @@ func (m *AAAFailureResponseLogout) validateCause(formats strfmt.Registry) error 
 		if err := m.Cause.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -75,6 +77,8 @@ func (m *AAAFailureResponseLogout) validateOriginal(formats strfmt.Registry) err
 		if err := m.Original.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("original")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("original")
 			}
 			return err
 		}
@@ -107,6 +111,8 @@ func (m *AAAFailureResponseLogout) contextValidateCause(ctx context.Context, for
 		if err := m.Cause.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -121,6 +127,8 @@ func (m *AAAFailureResponseLogout) contextValidateOriginal(ctx context.Context, 
 		if err := m.Original.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("original")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("original")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_failure_response_logout_cause.go
+++ b/swagger_models/a_a_a_failure_response_logout_cause.go
@@ -23,8 +23,12 @@ import (
 type AAAFailureResponseLogoutCause string
 
 func NewAAAFailureResponseLogoutCause(value AAAFailureResponseLogoutCause) *AAAFailureResponseLogoutCause {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAAFailureResponseLogoutCause.
+func (m AAAFailureResponseLogoutCause) Pointer() *AAAFailureResponseLogoutCause {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_failure_response_query_all_session_details.go
+++ b/swagger_models/a_a_a_failure_response_query_all_session_details.go
@@ -51,6 +51,8 @@ func (m *AAAFailureResponseQueryAllSessionDetails) validateCause(formats strfmt.
 		if err := m.Cause.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -79,6 +81,8 @@ func (m *AAAFailureResponseQueryAllSessionDetails) contextValidateCause(ctx cont
 		if err := m.Cause.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_failure_response_query_all_session_details_cause.go
+++ b/swagger_models/a_a_a_failure_response_query_all_session_details_cause.go
@@ -23,8 +23,12 @@ import (
 type AAAFailureResponseQueryAllSessionDetailsCause string
 
 func NewAAAFailureResponseQueryAllSessionDetailsCause(value AAAFailureResponseQueryAllSessionDetailsCause) *AAAFailureResponseQueryAllSessionDetailsCause {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAAFailureResponseQueryAllSessionDetailsCause.
+func (m AAAFailureResponseQueryAllSessionDetailsCause) Pointer() *AAAFailureResponseQueryAllSessionDetailsCause {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_failure_response_session_details.go
+++ b/swagger_models/a_a_a_failure_response_session_details.go
@@ -55,6 +55,8 @@ func (m *AAAFailureResponseSessionDetails) validateCause(formats strfmt.Registry
 		if err := m.Cause.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -72,6 +74,8 @@ func (m *AAAFailureResponseSessionDetails) validateOriginal(formats strfmt.Regis
 		if err := m.Original.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("original")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("original")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *AAAFailureResponseSessionDetails) contextValidateCause(ctx context.Cont
 		if err := m.Cause.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -118,6 +124,8 @@ func (m *AAAFailureResponseSessionDetails) contextValidateOriginal(ctx context.C
 		if err := m.Original.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("original")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("original")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_failure_response_session_details_cause.go
+++ b/swagger_models/a_a_a_failure_response_session_details_cause.go
@@ -23,8 +23,12 @@ import (
 type AAAFailureResponseSessionDetailsCause string
 
 func NewAAAFailureResponseSessionDetailsCause(value AAAFailureResponseSessionDetailsCause) *AAAFailureResponseSessionDetailsCause {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAAFailureResponseSessionDetailsCause.
+func (m AAAFailureResponseSessionDetailsCause) Pointer() *AAAFailureResponseSessionDetailsCause {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_failure_response_type.go
+++ b/swagger_models/a_a_a_failure_response_type.go
@@ -23,8 +23,12 @@ import (
 type AAAFailureResponseType string
 
 func NewAAAFailureResponseType(value AAAFailureResponseType) *AAAFailureResponseType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAAFailureResponseType.
+func (m AAAFailureResponseType) Pointer() *AAAFailureResponseType {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_failure_token_refresh.go
+++ b/swagger_models/a_a_a_failure_token_refresh.go
@@ -58,6 +58,8 @@ func (m *AAAFailureTokenRefresh) validateCause(formats strfmt.Registry) error {
 		if err := m.Cause.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -75,6 +77,8 @@ func (m *AAAFailureTokenRefresh) validateOriginal(formats strfmt.Registry) error
 		if err := m.Original.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("original")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("original")
 			}
 			return err
 		}
@@ -107,6 +111,8 @@ func (m *AAAFailureTokenRefresh) contextValidateCause(ctx context.Context, forma
 		if err := m.Cause.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -121,6 +127,8 @@ func (m *AAAFailureTokenRefresh) contextValidateOriginal(ctx context.Context, fo
 		if err := m.Original.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("original")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("original")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_failure_token_refresh_cause.go
+++ b/swagger_models/a_a_a_failure_token_refresh_cause.go
@@ -23,8 +23,12 @@ import (
 type AAAFailureTokenRefreshCause string
 
 func NewAAAFailureTokenRefreshCause(value AAAFailureTokenRefreshCause) *AAAFailureTokenRefreshCause {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAAFailureTokenRefreshCause.
+func (m AAAFailureTokenRefreshCause) Pointer() *AAAFailureTokenRefreshCause {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_frontend_generate_token_response.go
+++ b/swagger_models/a_a_a_frontend_generate_token_response.go
@@ -72,6 +72,8 @@ func (m *AAAFrontendGenerateTokenResponse) validateCause(formats strfmt.Registry
 		if err := m.Cause.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -112,6 +114,8 @@ func (m *AAAFrontendGenerateTokenResponse) contextValidateCause(ctx context.Cont
 		if err := m.Cause.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_frontend_generate_token_response_cause.go
+++ b/swagger_models/a_a_a_frontend_generate_token_response_cause.go
@@ -23,8 +23,12 @@ import (
 type AAAFrontendGenerateTokenResponseCause string
 
 func NewAAAFrontendGenerateTokenResponseCause(value AAAFrontendGenerateTokenResponseCause) *AAAFrontendGenerateTokenResponseCause {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAAFrontendGenerateTokenResponseCause.
+func (m AAAFrontendGenerateTokenResponseCause) Pointer() *AAAFrontendGenerateTokenResponseCause {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_frontend_login_mode_response.go
+++ b/swagger_models/a_a_a_frontend_login_mode_response.go
@@ -51,6 +51,8 @@ func (m *AAAFrontendLoginModeResponse) validateMode(formats strfmt.Registry) err
 		if err := m.Mode.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("mode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("mode")
 			}
 			return err
 		}
@@ -79,6 +81,8 @@ func (m *AAAFrontendLoginModeResponse) contextValidateMode(ctx context.Context, 
 		if err := m.Mode.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("mode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("mode")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_frontend_login_mode_response_mode.go
+++ b/swagger_models/a_a_a_frontend_login_mode_response_mode.go
@@ -23,8 +23,12 @@ import (
 type AAAFrontendLoginModeResponseMode string
 
 func NewAAAFrontendLoginModeResponseMode(value AAAFrontendLoginModeResponseMode) *AAAFrontendLoginModeResponseMode {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAAFrontendLoginModeResponseMode.
+func (m AAAFrontendLoginModeResponseMode) Pointer() *AAAFrontendLoginModeResponseMode {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_frontend_login_response.go
+++ b/swagger_models/a_a_a_frontend_login_response.go
@@ -121,6 +121,8 @@ func (m *AAAFrontendLoginResponse) validateAPIToken(formats strfmt.Registry) err
 		if err := m.APIToken.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("apiToken")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("apiToken")
 			}
 			return err
 		}
@@ -138,6 +140,8 @@ func (m *AAAFrontendLoginResponse) validateCause(formats strfmt.Registry) error 
 		if err := m.Cause.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -155,6 +159,8 @@ func (m *AAAFrontendLoginResponse) validateDetailedUser(formats strfmt.Registry)
 		if err := m.DetailedUser.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("detailedUser")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("detailedUser")
 			}
 			return err
 		}
@@ -172,6 +178,8 @@ func (m *AAAFrontendLoginResponse) validateEnterprise(formats strfmt.Registry) e
 		if err := m.Enterprise.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("enterprise")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("enterprise")
 			}
 			return err
 		}
@@ -189,6 +197,8 @@ func (m *AAAFrontendLoginResponse) validateLoginToken(formats strfmt.Registry) e
 		if err := m.LoginToken.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("loginToken")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("loginToken")
 			}
 			return err
 		}
@@ -211,6 +221,8 @@ func (m *AAAFrontendLoginResponse) validatePolicies(formats strfmt.Registry) err
 			if err := m.Policies[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("policies" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("policies" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -230,6 +242,8 @@ func (m *AAAFrontendLoginResponse) validateRealm(formats strfmt.Registry) error 
 		if err := m.Realm.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realm")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("realm")
 			}
 			return err
 		}
@@ -247,6 +261,8 @@ func (m *AAAFrontendLoginResponse) validateRole(formats strfmt.Registry) error {
 		if err := m.Role.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("role")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("role")
 			}
 			return err
 		}
@@ -264,6 +280,8 @@ func (m *AAAFrontendLoginResponse) validateSimpleUser(formats strfmt.Registry) e
 		if err := m.SimpleUser.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("simpleUser")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("simpleUser")
 			}
 			return err
 		}
@@ -281,6 +299,8 @@ func (m *AAAFrontendLoginResponse) validateToken(formats strfmt.Registry) error 
 		if err := m.Token.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("token")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("token")
 			}
 			return err
 		}
@@ -345,6 +365,8 @@ func (m *AAAFrontendLoginResponse) contextValidateAPIToken(ctx context.Context, 
 		if err := m.APIToken.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("apiToken")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("apiToken")
 			}
 			return err
 		}
@@ -359,6 +381,8 @@ func (m *AAAFrontendLoginResponse) contextValidateCause(ctx context.Context, for
 		if err := m.Cause.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -373,6 +397,8 @@ func (m *AAAFrontendLoginResponse) contextValidateDetailedUser(ctx context.Conte
 		if err := m.DetailedUser.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("detailedUser")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("detailedUser")
 			}
 			return err
 		}
@@ -387,6 +413,8 @@ func (m *AAAFrontendLoginResponse) contextValidateEnterprise(ctx context.Context
 		if err := m.Enterprise.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("enterprise")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("enterprise")
 			}
 			return err
 		}
@@ -401,6 +429,8 @@ func (m *AAAFrontendLoginResponse) contextValidateLoginToken(ctx context.Context
 		if err := m.LoginToken.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("loginToken")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("loginToken")
 			}
 			return err
 		}
@@ -417,6 +447,8 @@ func (m *AAAFrontendLoginResponse) contextValidatePolicies(ctx context.Context, 
 			if err := m.Policies[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("policies" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("policies" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -433,6 +465,8 @@ func (m *AAAFrontendLoginResponse) contextValidateRealm(ctx context.Context, for
 		if err := m.Realm.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realm")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("realm")
 			}
 			return err
 		}
@@ -447,6 +481,8 @@ func (m *AAAFrontendLoginResponse) contextValidateRole(ctx context.Context, form
 		if err := m.Role.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("role")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("role")
 			}
 			return err
 		}
@@ -461,6 +497,8 @@ func (m *AAAFrontendLoginResponse) contextValidateSimpleUser(ctx context.Context
 		if err := m.SimpleUser.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("simpleUser")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("simpleUser")
 			}
 			return err
 		}
@@ -475,6 +513,8 @@ func (m *AAAFrontendLoginResponse) contextValidateToken(ctx context.Context, for
 		if err := m.Token.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("token")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("token")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_frontend_login_response_cause.go
+++ b/swagger_models/a_a_a_frontend_login_response_cause.go
@@ -23,8 +23,12 @@ import (
 type AAAFrontendLoginResponseCause string
 
 func NewAAAFrontendLoginResponseCause(value AAAFrontendLoginResponseCause) *AAAFrontendLoginResponseCause {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAAFrontendLoginResponseCause.
+func (m AAAFrontendLoginResponseCause) Pointer() *AAAFrontendLoginResponseCause {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_frontend_logout_response.go
+++ b/swagger_models/a_a_a_frontend_logout_response.go
@@ -55,6 +55,8 @@ func (m *AAAFrontendLogoutResponse) validateCause(formats strfmt.Registry) error
 		if err := m.Cause.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -72,6 +74,8 @@ func (m *AAAFrontendLogoutResponse) validateToken(formats strfmt.Registry) error
 		if err := m.Token.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("token")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("token")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *AAAFrontendLogoutResponse) contextValidateCause(ctx context.Context, fo
 		if err := m.Cause.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -118,6 +124,8 @@ func (m *AAAFrontendLogoutResponse) contextValidateToken(ctx context.Context, fo
 		if err := m.Token.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("token")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("token")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_frontend_logout_response_cause.go
+++ b/swagger_models/a_a_a_frontend_logout_response_cause.go
@@ -23,8 +23,12 @@ import (
 type AAAFrontendLogoutResponseCause string
 
 func NewAAAFrontendLogoutResponseCause(value AAAFrontendLogoutResponseCause) *AAAFrontendLogoutResponseCause {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAAFrontendLogoutResponseCause.
+func (m AAAFrontendLogoutResponseCause) Pointer() *AAAFrontendLogoutResponseCause {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_frontend_refresh_response.go
+++ b/swagger_models/a_a_a_frontend_refresh_response.go
@@ -58,6 +58,8 @@ func (m *AAAFrontendRefreshResponse) validateCause(formats strfmt.Registry) erro
 		if err := m.Cause.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -75,6 +77,8 @@ func (m *AAAFrontendRefreshResponse) validateToken(formats strfmt.Registry) erro
 		if err := m.Token.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("token")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("token")
 			}
 			return err
 		}
@@ -107,6 +111,8 @@ func (m *AAAFrontendRefreshResponse) contextValidateCause(ctx context.Context, f
 		if err := m.Cause.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -121,6 +127,8 @@ func (m *AAAFrontendRefreshResponse) contextValidateToken(ctx context.Context, f
 		if err := m.Token.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("token")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("token")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_frontend_refresh_response_cause.go
+++ b/swagger_models/a_a_a_frontend_refresh_response_cause.go
@@ -23,8 +23,12 @@ import (
 type AAAFrontendRefreshResponseCause string
 
 func NewAAAFrontendRefreshResponseCause(value AAAFrontendRefreshResponseCause) *AAAFrontendRefreshResponseCause {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAAFrontendRefreshResponseCause.
+func (m AAAFrontendRefreshResponseCause) Pointer() *AAAFrontendRefreshResponseCause {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_frontend_session_details_response.go
+++ b/swagger_models/a_a_a_frontend_session_details_response.go
@@ -63,6 +63,8 @@ func (m *AAAFrontendSessionDetailsResponse) validateCause(formats strfmt.Registr
 		if err := m.Cause.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -85,6 +87,8 @@ func (m *AAAFrontendSessionDetailsResponse) validatePolicies(formats strfmt.Regi
 			if err := m.Policies[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("policies" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("policies" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -104,6 +108,8 @@ func (m *AAAFrontendSessionDetailsResponse) validateUser(formats strfmt.Registry
 		if err := m.User.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("user")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("user")
 			}
 			return err
 		}
@@ -140,6 +146,8 @@ func (m *AAAFrontendSessionDetailsResponse) contextValidateCause(ctx context.Con
 		if err := m.Cause.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -156,6 +164,8 @@ func (m *AAAFrontendSessionDetailsResponse) contextValidatePolicies(ctx context.
 			if err := m.Policies[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("policies" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("policies" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -172,6 +182,8 @@ func (m *AAAFrontendSessionDetailsResponse) contextValidateUser(ctx context.Cont
 		if err := m.User.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("user")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("user")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_frontend_session_details_response_cause.go
+++ b/swagger_models/a_a_a_frontend_session_details_response_cause.go
@@ -23,8 +23,12 @@ import (
 type AAAFrontendSessionDetailsResponseCause string
 
 func NewAAAFrontendSessionDetailsResponseCause(value AAAFrontendSessionDetailsResponseCause) *AAAFrontendSessionDetailsResponseCause {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAAFrontendSessionDetailsResponseCause.
+func (m AAAFrontendSessionDetailsResponseCause) Pointer() *AAAFrontendSessionDetailsResponseCause {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_login_mode_response.go
+++ b/swagger_models/a_a_a_login_mode_response.go
@@ -51,6 +51,8 @@ func (m *AAALoginModeResponse) validateMode(formats strfmt.Registry) error {
 		if err := m.Mode.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("mode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("mode")
 			}
 			return err
 		}
@@ -79,6 +81,8 @@ func (m *AAALoginModeResponse) contextValidateMode(ctx context.Context, formats 
 		if err := m.Mode.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("mode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("mode")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_login_mode_response_mode.go
+++ b/swagger_models/a_a_a_login_mode_response_mode.go
@@ -23,8 +23,12 @@ import (
 type AAALoginModeResponseMode string
 
 func NewAAALoginModeResponseMode(value AAALoginModeResponseMode) *AAALoginModeResponseMode {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAALoginModeResponseMode.
+func (m AAALoginModeResponseMode) Pointer() *AAALoginModeResponseMode {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_notify_response.go
+++ b/swagger_models/a_a_a_notify_response.go
@@ -62,6 +62,8 @@ func (m *AAANotifyResponse) validateLogin(formats strfmt.Registry) error {
 		if err := m.Login.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("login")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("login")
 			}
 			return err
 		}
@@ -79,6 +81,8 @@ func (m *AAANotifyResponse) validateLogout(formats strfmt.Registry) error {
 		if err := m.Logout.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("logout")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("logout")
 			}
 			return err
 		}
@@ -96,6 +100,8 @@ func (m *AAANotifyResponse) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -132,6 +138,8 @@ func (m *AAANotifyResponse) contextValidateLogin(ctx context.Context, formats st
 		if err := m.Login.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("login")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("login")
 			}
 			return err
 		}
@@ -146,6 +154,8 @@ func (m *AAANotifyResponse) contextValidateLogout(ctx context.Context, formats s
 		if err := m.Logout.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("logout")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("logout")
 			}
 			return err
 		}
@@ -160,6 +170,8 @@ func (m *AAANotifyResponse) contextValidateType(ctx context.Context, formats str
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_notify_response_type.go
+++ b/swagger_models/a_a_a_notify_response_type.go
@@ -23,8 +23,12 @@ import (
 type AAANotifyResponseType string
 
 func NewAAANotifyResponseType(value AAANotifyResponseType) *AAANotifyResponseType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAANotifyResponseType.
+func (m AAANotifyResponseType) Pointer() *AAANotifyResponseType {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_request_admin_user_signup.go
+++ b/swagger_models/a_a_a_request_admin_user_signup.go
@@ -66,6 +66,8 @@ func (m *AAARequestAdminUserSignup) validateType(formats strfmt.Registry) error 
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -94,6 +96,8 @@ func (m *AAARequestAdminUserSignup) contextValidateType(ctx context.Context, for
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_request_enterprise_signup.go
+++ b/swagger_models/a_a_a_request_enterprise_signup.go
@@ -68,6 +68,8 @@ func (m *AAARequestEnterpriseSignup) validateAdminUser(formats strfmt.Registry) 
 		if err := m.AdminUser.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("adminUser")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("adminUser")
 			}
 			return err
 		}
@@ -85,6 +87,8 @@ func (m *AAARequestEnterpriseSignup) validateEnterprise(formats strfmt.Registry)
 		if err := m.Enterprise.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("enterprise")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("enterprise")
 			}
 			return err
 		}
@@ -102,6 +106,8 @@ func (m *AAARequestEnterpriseSignup) validateProfileType(formats strfmt.Registry
 		if err := m.ProfileType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("profileType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("profileType")
 			}
 			return err
 		}
@@ -138,6 +144,8 @@ func (m *AAARequestEnterpriseSignup) contextValidateAdminUser(ctx context.Contex
 		if err := m.AdminUser.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("adminUser")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("adminUser")
 			}
 			return err
 		}
@@ -152,6 +160,8 @@ func (m *AAARequestEnterpriseSignup) contextValidateEnterprise(ctx context.Conte
 		if err := m.Enterprise.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("enterprise")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("enterprise")
 			}
 			return err
 		}
@@ -166,6 +176,8 @@ func (m *AAARequestEnterpriseSignup) contextValidateProfileType(ctx context.Cont
 		if err := m.ProfileType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("profileType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("profileType")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_response.go
+++ b/swagger_models/a_a_a_response.go
@@ -90,6 +90,8 @@ func (m *AAAResponse) validateFailure(formats strfmt.Registry) error {
 		if err := m.Failure.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("failure")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("failure")
 			}
 			return err
 		}
@@ -107,6 +109,8 @@ func (m *AAAResponse) validateMode(formats strfmt.Registry) error {
 		if err := m.Mode.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("mode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("mode")
 			}
 			return err
 		}
@@ -124,6 +128,8 @@ func (m *AAAResponse) validateNotify(formats strfmt.Registry) error {
 		if err := m.Notify.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("notify")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("notify")
 			}
 			return err
 		}
@@ -141,6 +147,8 @@ func (m *AAAResponse) validateRedirect(formats strfmt.Registry) error {
 		if err := m.Redirect.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("redirect")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("redirect")
 			}
 			return err
 		}
@@ -158,6 +166,8 @@ func (m *AAAResponse) validateResult(formats strfmt.Registry) error {
 		if err := m.Result.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("result")
 			}
 			return err
 		}
@@ -175,6 +185,8 @@ func (m *AAAResponse) validateSuccess(formats strfmt.Registry) error {
 		if err := m.Success.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("success")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("success")
 			}
 			return err
 		}
@@ -192,6 +204,8 @@ func (m *AAAResponse) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -244,6 +258,8 @@ func (m *AAAResponse) contextValidateFailure(ctx context.Context, formats strfmt
 		if err := m.Failure.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("failure")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("failure")
 			}
 			return err
 		}
@@ -258,6 +274,8 @@ func (m *AAAResponse) contextValidateMode(ctx context.Context, formats strfmt.Re
 		if err := m.Mode.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("mode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("mode")
 			}
 			return err
 		}
@@ -272,6 +290,8 @@ func (m *AAAResponse) contextValidateNotify(ctx context.Context, formats strfmt.
 		if err := m.Notify.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("notify")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("notify")
 			}
 			return err
 		}
@@ -286,6 +306,8 @@ func (m *AAAResponse) contextValidateRedirect(ctx context.Context, formats strfm
 		if err := m.Redirect.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("redirect")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("redirect")
 			}
 			return err
 		}
@@ -300,6 +322,8 @@ func (m *AAAResponse) contextValidateResult(ctx context.Context, formats strfmt.
 		if err := m.Result.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("result")
 			}
 			return err
 		}
@@ -314,6 +338,8 @@ func (m *AAAResponse) contextValidateSuccess(ctx context.Context, formats strfmt
 		if err := m.Success.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("success")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("success")
 			}
 			return err
 		}
@@ -328,6 +354,8 @@ func (m *AAAResponse) contextValidateType(ctx context.Context, formats strfmt.Re
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_response_type.go
+++ b/swagger_models/a_a_a_response_type.go
@@ -23,8 +23,12 @@ import (
 type AAAResponseType string
 
 func NewAAAResponseType(value AAAResponseType) *AAAResponseType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAAResponseType.
+func (m AAAResponseType) Pointer() *AAAResponseType {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_success_response.go
+++ b/swagger_models/a_a_a_success_response.go
@@ -97,6 +97,8 @@ func (m *AAASuccessResponse) validateCredential(formats strfmt.Registry) error {
 		if err := m.Credential.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("credential")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("credential")
 			}
 			return err
 		}
@@ -114,6 +116,8 @@ func (m *AAASuccessResponse) validateDetails(formats strfmt.Registry) error {
 		if err := m.Details.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("details")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("details")
 			}
 			return err
 		}
@@ -131,6 +135,8 @@ func (m *AAASuccessResponse) validateGenerateToken(formats strfmt.Registry) erro
 		if err := m.GenerateToken.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("generateToken")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("generateToken")
 			}
 			return err
 		}
@@ -148,6 +154,8 @@ func (m *AAASuccessResponse) validateLogin(formats strfmt.Registry) error {
 		if err := m.Login.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("login")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("login")
 			}
 			return err
 		}
@@ -165,6 +173,8 @@ func (m *AAASuccessResponse) validateLogout(formats strfmt.Registry) error {
 		if err := m.Logout.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("logout")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("logout")
 			}
 			return err
 		}
@@ -182,6 +192,8 @@ func (m *AAASuccessResponse) validateQuerySessionDetails(formats strfmt.Registry
 		if err := m.QuerySessionDetails.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("querySessionDetails")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("querySessionDetails")
 			}
 			return err
 		}
@@ -199,6 +211,8 @@ func (m *AAASuccessResponse) validateRefresh(formats strfmt.Registry) error {
 		if err := m.Refresh.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("refresh")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("refresh")
 			}
 			return err
 		}
@@ -216,6 +230,8 @@ func (m *AAASuccessResponse) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -272,6 +288,8 @@ func (m *AAASuccessResponse) contextValidateCredential(ctx context.Context, form
 		if err := m.Credential.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("credential")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("credential")
 			}
 			return err
 		}
@@ -286,6 +304,8 @@ func (m *AAASuccessResponse) contextValidateDetails(ctx context.Context, formats
 		if err := m.Details.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("details")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("details")
 			}
 			return err
 		}
@@ -300,6 +320,8 @@ func (m *AAASuccessResponse) contextValidateGenerateToken(ctx context.Context, f
 		if err := m.GenerateToken.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("generateToken")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("generateToken")
 			}
 			return err
 		}
@@ -314,6 +336,8 @@ func (m *AAASuccessResponse) contextValidateLogin(ctx context.Context, formats s
 		if err := m.Login.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("login")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("login")
 			}
 			return err
 		}
@@ -328,6 +352,8 @@ func (m *AAASuccessResponse) contextValidateLogout(ctx context.Context, formats 
 		if err := m.Logout.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("logout")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("logout")
 			}
 			return err
 		}
@@ -342,6 +368,8 @@ func (m *AAASuccessResponse) contextValidateQuerySessionDetails(ctx context.Cont
 		if err := m.QuerySessionDetails.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("querySessionDetails")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("querySessionDetails")
 			}
 			return err
 		}
@@ -356,6 +384,8 @@ func (m *AAASuccessResponse) contextValidateRefresh(ctx context.Context, formats
 		if err := m.Refresh.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("refresh")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("refresh")
 			}
 			return err
 		}
@@ -370,6 +400,8 @@ func (m *AAASuccessResponse) contextValidateType(ctx context.Context, formats st
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_success_response_generate_token.go
+++ b/swagger_models/a_a_a_success_response_generate_token.go
@@ -55,6 +55,8 @@ func (m *AAASuccessResponseGenerateToken) validateLogin(formats strfmt.Registry)
 		if err := m.Login.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("login")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("login")
 			}
 			return err
 		}
@@ -72,6 +74,8 @@ func (m *AAASuccessResponseGenerateToken) validateSessionDetails(formats strfmt.
 		if err := m.SessionDetails.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("sessionDetails")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sessionDetails")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *AAASuccessResponseGenerateToken) contextValidateLogin(ctx context.Conte
 		if err := m.Login.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("login")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("login")
 			}
 			return err
 		}
@@ -118,6 +124,8 @@ func (m *AAASuccessResponseGenerateToken) contextValidateSessionDetails(ctx cont
 		if err := m.SessionDetails.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("sessionDetails")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sessionDetails")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_success_response_login.go
+++ b/swagger_models/a_a_a_success_response_login.go
@@ -126,6 +126,8 @@ func (m *AAASuccessResponseLogin) validateAPIToken(formats strfmt.Registry) erro
 		if err := m.APIToken.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("apiToken")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("apiToken")
 			}
 			return err
 		}
@@ -143,6 +145,8 @@ func (m *AAASuccessResponseLogin) validateDetailedUser(formats strfmt.Registry) 
 		if err := m.DetailedUser.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("detailedUser")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("detailedUser")
 			}
 			return err
 		}
@@ -160,6 +164,8 @@ func (m *AAASuccessResponseLogin) validateEnterprise(formats strfmt.Registry) er
 		if err := m.Enterprise.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("enterprise")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("enterprise")
 			}
 			return err
 		}
@@ -177,6 +183,8 @@ func (m *AAASuccessResponseLogin) validateEnterpriseID(formats strfmt.Registry) 
 		if err := m.EnterpriseID.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("enterpriseId")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("enterpriseId")
 			}
 			return err
 		}
@@ -194,6 +202,8 @@ func (m *AAASuccessResponseLogin) validateLoginToken(formats strfmt.Registry) er
 		if err := m.LoginToken.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("loginToken")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("loginToken")
 			}
 			return err
 		}
@@ -216,6 +226,8 @@ func (m *AAASuccessResponseLogin) validatePolicies(formats strfmt.Registry) erro
 			if err := m.Policies[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("policies" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("policies" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -235,6 +247,8 @@ func (m *AAASuccessResponseLogin) validateRealm(formats strfmt.Registry) error {
 		if err := m.Realm.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realm")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("realm")
 			}
 			return err
 		}
@@ -252,6 +266,8 @@ func (m *AAASuccessResponseLogin) validateRealmID(formats strfmt.Registry) error
 		if err := m.RealmID.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realmId")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("realmId")
 			}
 			return err
 		}
@@ -269,6 +285,8 @@ func (m *AAASuccessResponseLogin) validateRole(formats strfmt.Registry) error {
 		if err := m.Role.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("role")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("role")
 			}
 			return err
 		}
@@ -286,6 +304,8 @@ func (m *AAASuccessResponseLogin) validateSimpleUser(formats strfmt.Registry) er
 		if err := m.SimpleUser.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("simpleUser")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("simpleUser")
 			}
 			return err
 		}
@@ -303,6 +323,8 @@ func (m *AAASuccessResponseLogin) validateToken(formats strfmt.Registry) error {
 		if err := m.Token.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("token")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("token")
 			}
 			return err
 		}
@@ -320,6 +342,8 @@ func (m *AAASuccessResponseLogin) validateUserID(formats strfmt.Registry) error 
 		if err := m.UserID.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("userId")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("userId")
 			}
 			return err
 		}
@@ -392,6 +416,8 @@ func (m *AAASuccessResponseLogin) contextValidateAPIToken(ctx context.Context, f
 		if err := m.APIToken.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("apiToken")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("apiToken")
 			}
 			return err
 		}
@@ -406,6 +432,8 @@ func (m *AAASuccessResponseLogin) contextValidateDetailedUser(ctx context.Contex
 		if err := m.DetailedUser.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("detailedUser")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("detailedUser")
 			}
 			return err
 		}
@@ -420,6 +448,8 @@ func (m *AAASuccessResponseLogin) contextValidateEnterprise(ctx context.Context,
 		if err := m.Enterprise.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("enterprise")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("enterprise")
 			}
 			return err
 		}
@@ -434,6 +464,8 @@ func (m *AAASuccessResponseLogin) contextValidateEnterpriseID(ctx context.Contex
 		if err := m.EnterpriseID.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("enterpriseId")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("enterpriseId")
 			}
 			return err
 		}
@@ -448,6 +480,8 @@ func (m *AAASuccessResponseLogin) contextValidateLoginToken(ctx context.Context,
 		if err := m.LoginToken.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("loginToken")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("loginToken")
 			}
 			return err
 		}
@@ -464,6 +498,8 @@ func (m *AAASuccessResponseLogin) contextValidatePolicies(ctx context.Context, f
 			if err := m.Policies[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("policies" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("policies" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -480,6 +516,8 @@ func (m *AAASuccessResponseLogin) contextValidateRealm(ctx context.Context, form
 		if err := m.Realm.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realm")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("realm")
 			}
 			return err
 		}
@@ -494,6 +532,8 @@ func (m *AAASuccessResponseLogin) contextValidateRealmID(ctx context.Context, fo
 		if err := m.RealmID.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realmId")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("realmId")
 			}
 			return err
 		}
@@ -508,6 +548,8 @@ func (m *AAASuccessResponseLogin) contextValidateRole(ctx context.Context, forma
 		if err := m.Role.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("role")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("role")
 			}
 			return err
 		}
@@ -522,6 +564,8 @@ func (m *AAASuccessResponseLogin) contextValidateSimpleUser(ctx context.Context,
 		if err := m.SimpleUser.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("simpleUser")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("simpleUser")
 			}
 			return err
 		}
@@ -536,6 +580,8 @@ func (m *AAASuccessResponseLogin) contextValidateToken(ctx context.Context, form
 		if err := m.Token.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("token")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("token")
 			}
 			return err
 		}
@@ -550,6 +596,8 @@ func (m *AAASuccessResponseLogin) contextValidateUserID(ctx context.Context, for
 		if err := m.UserID.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("userId")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("userId")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_success_response_logout.go
+++ b/swagger_models/a_a_a_success_response_logout.go
@@ -48,6 +48,8 @@ func (m *AAASuccessResponseLogout) validateOriginal(formats strfmt.Registry) err
 		if err := m.Original.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("original")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("original")
 			}
 			return err
 		}
@@ -76,6 +78,8 @@ func (m *AAASuccessResponseLogout) contextValidateOriginal(ctx context.Context, 
 		if err := m.Original.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("original")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("original")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_success_response_query_all_session_details.go
+++ b/swagger_models/a_a_a_success_response_query_all_session_details.go
@@ -56,6 +56,8 @@ func (m *AAASuccessResponseQueryAllSessionDetails) validateCause(formats strfmt.
 		if err := m.Cause.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -78,6 +80,8 @@ func (m *AAASuccessResponseQueryAllSessionDetails) validateSessionDetails(format
 			if err := m.SessionDetails[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("sessionDetails" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("sessionDetails" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -112,6 +116,8 @@ func (m *AAASuccessResponseQueryAllSessionDetails) contextValidateCause(ctx cont
 		if err := m.Cause.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -128,6 +134,8 @@ func (m *AAASuccessResponseQueryAllSessionDetails) contextValidateSessionDetails
 			if err := m.SessionDetails[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("sessionDetails" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("sessionDetails" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/a_a_a_success_response_query_all_session_details_cause.go
+++ b/swagger_models/a_a_a_success_response_query_all_session_details_cause.go
@@ -23,8 +23,12 @@ import (
 type AAASuccessResponseQueryAllSessionDetailsCause string
 
 func NewAAASuccessResponseQueryAllSessionDetailsCause(value AAASuccessResponseQueryAllSessionDetailsCause) *AAASuccessResponseQueryAllSessionDetailsCause {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAASuccessResponseQueryAllSessionDetailsCause.
+func (m AAASuccessResponseQueryAllSessionDetailsCause) Pointer() *AAASuccessResponseQueryAllSessionDetailsCause {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_success_response_type.go
+++ b/swagger_models/a_a_a_success_response_type.go
@@ -23,8 +23,12 @@ import (
 type AAASuccessResponseType string
 
 func NewAAASuccessResponseType(value AAASuccessResponseType) *AAASuccessResponseType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AAASuccessResponseType.
+func (m AAASuccessResponseType) Pointer() *AAASuccessResponseType {
+	return &m
 }
 
 const (

--- a/swagger_models/a_a_a_success_session_details_response.go
+++ b/swagger_models/a_a_a_success_session_details_response.go
@@ -63,6 +63,8 @@ func (m *AAASuccessSessionDetailsResponse) validateOriginal(formats strfmt.Regis
 		if err := m.Original.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("original")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("original")
 			}
 			return err
 		}
@@ -85,6 +87,8 @@ func (m *AAASuccessSessionDetailsResponse) validatePolicies(formats strfmt.Regis
 			if err := m.Policies[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("policies" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("policies" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -104,6 +108,8 @@ func (m *AAASuccessSessionDetailsResponse) validateUser(formats strfmt.Registry)
 		if err := m.User.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("user")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("user")
 			}
 			return err
 		}
@@ -140,6 +146,8 @@ func (m *AAASuccessSessionDetailsResponse) contextValidateOriginal(ctx context.C
 		if err := m.Original.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("original")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("original")
 			}
 			return err
 		}
@@ -156,6 +164,8 @@ func (m *AAASuccessSessionDetailsResponse) contextValidatePolicies(ctx context.C
 			if err := m.Policies[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("policies" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("policies" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -172,6 +182,8 @@ func (m *AAASuccessSessionDetailsResponse) contextValidateUser(ctx context.Conte
 		if err := m.User.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("user")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("user")
 			}
 			return err
 		}

--- a/swagger_models/a_a_a_success_token_refresh.go
+++ b/swagger_models/a_a_a_success_token_refresh.go
@@ -48,6 +48,8 @@ func (m *AAASuccessTokenRefresh) validateToken(formats strfmt.Registry) error {
 		if err := m.Token.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("token")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("token")
 			}
 			return err
 		}
@@ -76,6 +78,8 @@ func (m *AAASuccessTokenRefresh) contextValidateToken(ctx context.Context, forma
 		if err := m.Token.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("token")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("token")
 			}
 			return err
 		}

--- a/swagger_models/acl.go
+++ b/swagger_models/acl.go
@@ -64,6 +64,8 @@ func (m *ACL) validateActions(formats strfmt.Registry) error {
 			if err := m.Actions[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("actions" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("actions" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -88,6 +90,8 @@ func (m *ACL) validateMatches(formats strfmt.Registry) error {
 			if err := m.Matches[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("matches" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("matches" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -124,6 +128,8 @@ func (m *ACL) contextValidateActions(ctx context.Context, formats strfmt.Registr
 			if err := m.Actions[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("actions" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("actions" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -142,6 +148,8 @@ func (m *ACL) contextValidateMatches(ctx context.Context, formats strfmt.Registr
 			if err := m.Matches[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("matches" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("matches" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/acl_action.go
+++ b/swagger_models/acl_action.go
@@ -86,6 +86,8 @@ func (m *ACLAction) validateLimitValue(formats strfmt.Registry) error {
 		if err := m.LimitValue.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("limitValue")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("limitValue")
 			}
 			return err
 		}
@@ -103,6 +105,8 @@ func (m *ACLAction) validatePortmapto(formats strfmt.Registry) error {
 		if err := m.Portmapto.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("portmapto")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("portmapto")
 			}
 			return err
 		}
@@ -135,6 +139,8 @@ func (m *ACLAction) contextValidateLimitValue(ctx context.Context, formats strfm
 		if err := m.LimitValue.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("limitValue")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("limitValue")
 			}
 			return err
 		}
@@ -149,6 +155,8 @@ func (m *ACLAction) contextValidatePortmapto(ctx context.Context, formats strfmt
 		if err := m.Portmapto.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("portmapto")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("portmapto")
 			}
 			return err
 		}

--- a/swagger_models/action_scope.go
+++ b/swagger_models/action_scope.go
@@ -51,6 +51,8 @@ func (m *ActionScope) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -79,6 +81,8 @@ func (m *ActionScope) contextValidateType(ctx context.Context, formats strfmt.Re
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/adapter_usage.go
+++ b/swagger_models/adapter_usage.go
@@ -29,8 +29,12 @@ import (
 type AdapterUsage string
 
 func NewAdapterUsage(value AdapterUsage) *AdapterUsage {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AdapterUsage.
+func (m AdapterUsage) Pointer() *AdapterUsage {
+	return &m
 }
 
 const (

--- a/swagger_models/admin_state.go
+++ b/swagger_models/admin_state.go
@@ -29,8 +29,12 @@ import (
 type AdminState string
 
 func NewAdminState(value AdminState) *AdminState {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AdminState.
+func (m AdminState) Pointer() *AdminState {
+	return &m
 }
 
 const (

--- a/swagger_models/admin_user_signup.go
+++ b/swagger_models/admin_user_signup.go
@@ -63,6 +63,8 @@ func (m *AdminUserSignup) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -91,6 +93,8 @@ func (m *AdminUserSignup) contextValidateType(ctx context.Context, formats strfm
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/allocation_policy.go
+++ b/swagger_models/allocation_policy.go
@@ -23,8 +23,12 @@ import (
 type AllocationPolicy string
 
 func NewAllocationPolicy(value AllocationPolicy) *AllocationPolicy {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AllocationPolicy.
+func (m AllocationPolicy) Pointer() *AllocationPolicy {
+	return &m
 }
 
 const (

--- a/swagger_models/app.go
+++ b/swagger_models/app.go
@@ -156,6 +156,8 @@ func (m *App) validateManifestJSON(formats strfmt.Registry) error {
 		if err := m.ManifestJSON.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("manifestJSON")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("manifestJSON")
 			}
 			return err
 		}
@@ -199,6 +201,8 @@ func (m *App) validateOriginType(formats strfmt.Registry) error {
 		if err := m.OriginType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -216,6 +220,8 @@ func (m *App) validateParentDetail(formats strfmt.Registry) error {
 		if err := m.ParentDetail.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("parentDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("parentDetail")
 			}
 			return err
 		}
@@ -233,6 +239,8 @@ func (m *App) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -320,6 +328,8 @@ func (m *App) contextValidateManifestJSON(ctx context.Context, formats strfmt.Re
 		if err := m.ManifestJSON.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("manifestJSON")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("manifestJSON")
 			}
 			return err
 		}
@@ -334,6 +344,8 @@ func (m *App) contextValidateOriginType(ctx context.Context, formats strfmt.Regi
 		if err := m.OriginType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -348,6 +360,8 @@ func (m *App) contextValidateParentDetail(ctx context.Context, formats strfmt.Re
 		if err := m.ParentDetail.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("parentDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("parentDetail")
 			}
 			return err
 		}
@@ -362,6 +376,8 @@ func (m *App) contextValidateRevision(ctx context.Context, formats strfmt.Regist
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}

--- a/swagger_models/app_a_c_e.go
+++ b/swagger_models/app_a_c_e.go
@@ -86,6 +86,8 @@ func (m *AppACE) validateActions(formats strfmt.Registry) error {
 			if err := m.Actions[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("actions" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("actions" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -120,6 +122,8 @@ func (m *AppACE) validateMatches(formats strfmt.Registry) error {
 			if err := m.Matches[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("matches" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("matches" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -177,6 +181,8 @@ func (m *AppACE) contextValidateActions(ctx context.Context, formats strfmt.Regi
 			if err := m.Actions[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("actions" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("actions" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -195,6 +201,8 @@ func (m *AppACE) contextValidateMatches(ctx context.Context, formats strfmt.Regi
 			if err := m.Matches[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("matches" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("matches" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/app_a_c_e_action.go
+++ b/swagger_models/app_a_c_e_action.go
@@ -146,6 +146,8 @@ func (m *AppACEAction) validateMapparams(formats strfmt.Registry) error {
 		if err := m.Mapparams.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("mapparams")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("mapparams")
 			}
 			return err
 		}
@@ -183,6 +185,8 @@ func (m *AppACEAction) contextValidateMapparams(ctx context.Context, formats str
 		if err := m.Mapparams.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("mapparams")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("mapparams")
 			}
 			return err
 		}

--- a/swagger_models/app_category.go
+++ b/swagger_models/app_category.go
@@ -34,8 +34,12 @@ import (
 type AppCategory string
 
 func NewAppCategory(value AppCategory) *AppCategory {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AppCategory.
+func (m AppCategory) Pointer() *AppCategory {
+	return &m
 }
 
 const (

--- a/swagger_models/app_config.go
+++ b/swagger_models/app_config.go
@@ -207,6 +207,8 @@ func (m *AppConfig) validateInterfaces(formats strfmt.Registry) error {
 			if err := m.Interfaces[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("interfaces" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("interfaces" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -227,6 +229,8 @@ func (m *AppConfig) validateManifestJSON(formats strfmt.Registry) error {
 		if err := m.ManifestJSON.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("manifestJSON")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("manifestJSON")
 			}
 			return err
 		}
@@ -265,6 +269,8 @@ func (m *AppConfig) validateNamingScheme(formats strfmt.Registry) error {
 		if err := m.NamingScheme.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("namingScheme")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("namingScheme")
 			}
 			return err
 		}
@@ -282,6 +288,8 @@ func (m *AppConfig) validateOriginType(formats strfmt.Registry) error {
 		if err := m.OriginType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -299,6 +307,8 @@ func (m *AppConfig) validateParentDetail(formats strfmt.Registry) error {
 		if err := m.ParentDetail.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("parentDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("parentDetail")
 			}
 			return err
 		}
@@ -392,6 +402,8 @@ func (m *AppConfig) contextValidateInterfaces(ctx context.Context, formats strfm
 			if err := m.Interfaces[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("interfaces" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("interfaces" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -408,6 +420,8 @@ func (m *AppConfig) contextValidateManifestJSON(ctx context.Context, formats str
 		if err := m.ManifestJSON.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("manifestJSON")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("manifestJSON")
 			}
 			return err
 		}
@@ -422,6 +436,8 @@ func (m *AppConfig) contextValidateNamingScheme(ctx context.Context, formats str
 		if err := m.NamingScheme.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("namingScheme")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("namingScheme")
 			}
 			return err
 		}
@@ -436,6 +452,8 @@ func (m *AppConfig) contextValidateOriginType(ctx context.Context, formats strfm
 		if err := m.OriginType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -450,6 +468,8 @@ func (m *AppConfig) contextValidateParentDetail(ctx context.Context, formats str
 		if err := m.ParentDetail.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("parentDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("parentDetail")
 			}
 			return err
 		}

--- a/swagger_models/app_filter.go
+++ b/swagger_models/app_filter.go
@@ -77,6 +77,8 @@ func (m *AppFilter) validateAppCategory(formats strfmt.Registry) error {
 		if err := m.AppCategory.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appCategory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appCategory")
 			}
 			return err
 		}
@@ -94,6 +96,8 @@ func (m *AppFilter) validateAppType(formats strfmt.Registry) error {
 		if err := m.AppType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -111,6 +115,8 @@ func (m *AppFilter) validateDeploymentType(formats strfmt.Registry) error {
 		if err := m.DeploymentType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}
@@ -128,6 +134,8 @@ func (m *AppFilter) validateOriginType(formats strfmt.Registry) error {
 		if err := m.OriginType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -168,6 +176,8 @@ func (m *AppFilter) contextValidateAppCategory(ctx context.Context, formats strf
 		if err := m.AppCategory.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appCategory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appCategory")
 			}
 			return err
 		}
@@ -182,6 +192,8 @@ func (m *AppFilter) contextValidateAppType(ctx context.Context, formats strfmt.R
 		if err := m.AppType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -196,6 +208,8 @@ func (m *AppFilter) contextValidateDeploymentType(ctx context.Context, formats s
 		if err := m.DeploymentType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}
@@ -210,6 +224,8 @@ func (m *AppFilter) contextValidateOriginType(ctx context.Context, formats strfm
 		if err := m.OriginType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}

--- a/swagger_models/app_inst_filter.go
+++ b/swagger_models/app_inst_filter.go
@@ -109,6 +109,8 @@ func (m *AppInstFilter) validateAppType(formats strfmt.Registry) error {
 		if err := m.AppType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -126,6 +128,8 @@ func (m *AppInstFilter) validateDeploymentType(formats strfmt.Registry) error {
 		if err := m.DeploymentType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}
@@ -198,6 +202,8 @@ func (m *AppInstFilter) contextValidateAppType(ctx context.Context, formats strf
 		if err := m.AppType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -212,6 +218,8 @@ func (m *AppInstFilter) contextValidateDeploymentType(ctx context.Context, forma
 		if err := m.DeploymentType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}

--- a/swagger_models/app_inst_status_filter.go
+++ b/swagger_models/app_inst_status_filter.go
@@ -119,6 +119,8 @@ func (m *AppInstStatusFilter) validateAppType(formats strfmt.Registry) error {
 		if err := m.AppType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -136,6 +138,8 @@ func (m *AppInstStatusFilter) validateDeploymentType(formats strfmt.Registry) er
 		if err := m.DeploymentType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}
@@ -193,6 +197,8 @@ func (m *AppInstStatusFilter) validateRunState(formats strfmt.Registry) error {
 		if err := m.RunState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -229,6 +235,8 @@ func (m *AppInstStatusFilter) contextValidateAppType(ctx context.Context, format
 		if err := m.AppType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -243,6 +251,8 @@ func (m *AppInstStatusFilter) contextValidateDeploymentType(ctx context.Context,
 		if err := m.DeploymentType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}
@@ -257,6 +267,8 @@ func (m *AppInstStatusFilter) contextValidateRunState(ctx context.Context, forma
 		if err := m.RunState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}

--- a/swagger_models/app_inst_status_list_msg.go
+++ b/swagger_models/app_inst_status_list_msg.go
@@ -70,6 +70,8 @@ func (m *AppInstStatusListMsg) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -89,6 +91,8 @@ func (m *AppInstStatusListMsg) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -106,6 +110,8 @@ func (m *AppInstStatusListMsg) validateSummaryByState(formats strfmt.Registry) e
 		if err := m.SummaryByState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -144,6 +150,8 @@ func (m *AppInstStatusListMsg) contextValidateList(ctx context.Context, formats 
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -160,6 +168,8 @@ func (m *AppInstStatusListMsg) contextValidateNext(ctx context.Context, formats 
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -174,6 +184,8 @@ func (m *AppInstStatusListMsg) contextValidateSummaryByState(ctx context.Context
 		if err := m.SummaryByState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}

--- a/swagger_models/app_inst_status_msg.go
+++ b/swagger_models/app_inst_status_msg.go
@@ -233,6 +233,8 @@ func (m *AppInstStatusMsg) validateCPU(formats strfmt.Registry) error {
 		if err := m.CPU.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Cpu")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Cpu")
 			}
 			return err
 		}
@@ -255,6 +257,8 @@ func (m *AppInstStatusMsg) validateIoStatusList(formats strfmt.Registry) error {
 			if err := m.IoStatusList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("IoStatusList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("IoStatusList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -274,6 +278,8 @@ func (m *AppInstStatusMsg) validateMemory(formats strfmt.Registry) error {
 		if err := m.Memory.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Memory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Memory")
 			}
 			return err
 		}
@@ -291,6 +297,8 @@ func (m *AppInstStatusMsg) validateStorage(formats strfmt.Registry) error {
 		if err := m.Storage.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Storage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Storage")
 			}
 			return err
 		}
@@ -308,6 +316,8 @@ func (m *AppInstStatusMsg) validateAdminState(formats strfmt.Registry) error {
 		if err := m.AdminState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("adminState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("adminState")
 			}
 			return err
 		}
@@ -345,6 +355,8 @@ func (m *AppInstStatusMsg) validateAppStatusFromTPController(formats strfmt.Regi
 		if err := m.AppStatusFromTPController.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appStatusFromTPController")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appStatusFromTPController")
 			}
 			return err
 		}
@@ -362,6 +374,8 @@ func (m *AppInstStatusMsg) validateAppType(formats strfmt.Registry) error {
 		if err := m.AppType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -411,6 +425,8 @@ func (m *AppInstStatusMsg) validateDeploymentType(formats strfmt.Registry) error
 		if err := m.DeploymentType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}
@@ -453,6 +469,8 @@ func (m *AppInstStatusMsg) validateErrInfo(formats strfmt.Registry) error {
 			if err := m.ErrInfo[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("errInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("errInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -484,6 +502,8 @@ func (m *AppInstStatusMsg) validateMemorySummary(formats strfmt.Registry) error 
 		if err := m.MemorySummary.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("memorySummary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("memorySummary")
 			}
 			return err
 		}
@@ -526,6 +546,8 @@ func (m *AppInstStatusMsg) validateNetCounterList(formats strfmt.Registry) error
 			if err := m.NetCounterList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("netCounterList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("netCounterList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -550,6 +572,8 @@ func (m *AppInstStatusMsg) validateNetStatusList(formats strfmt.Registry) error 
 			if err := m.NetStatusList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("netStatusList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("netStatusList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -589,6 +613,8 @@ func (m *AppInstStatusMsg) validateRunState(formats strfmt.Registry) error {
 		if err := m.RunState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -611,6 +637,8 @@ func (m *AppInstStatusMsg) validateSwInfo(formats strfmt.Registry) error {
 			if err := m.SwInfo[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("swInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("swInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -630,6 +658,8 @@ func (m *AppInstStatusMsg) validateSwState(formats strfmt.Registry) error {
 		if err := m.SwState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("swState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("swState")
 			}
 			return err
 		}
@@ -726,6 +756,8 @@ func (m *AppInstStatusMsg) contextValidateCPU(ctx context.Context, formats strfm
 		if err := m.CPU.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Cpu")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Cpu")
 			}
 			return err
 		}
@@ -742,6 +774,8 @@ func (m *AppInstStatusMsg) contextValidateIoStatusList(ctx context.Context, form
 			if err := m.IoStatusList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("IoStatusList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("IoStatusList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -758,6 +792,8 @@ func (m *AppInstStatusMsg) contextValidateMemory(ctx context.Context, formats st
 		if err := m.Memory.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Memory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Memory")
 			}
 			return err
 		}
@@ -772,6 +808,8 @@ func (m *AppInstStatusMsg) contextValidateStorage(ctx context.Context, formats s
 		if err := m.Storage.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Storage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Storage")
 			}
 			return err
 		}
@@ -786,6 +824,8 @@ func (m *AppInstStatusMsg) contextValidateAdminState(ctx context.Context, format
 		if err := m.AdminState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("adminState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("adminState")
 			}
 			return err
 		}
@@ -800,6 +840,8 @@ func (m *AppInstStatusMsg) contextValidateAppStatusFromTPController(ctx context.
 		if err := m.AppStatusFromTPController.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appStatusFromTPController")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appStatusFromTPController")
 			}
 			return err
 		}
@@ -814,6 +856,8 @@ func (m *AppInstStatusMsg) contextValidateAppType(ctx context.Context, formats s
 		if err := m.AppType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -828,6 +872,8 @@ func (m *AppInstStatusMsg) contextValidateDeploymentType(ctx context.Context, fo
 		if err := m.DeploymentType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}
@@ -844,6 +890,8 @@ func (m *AppInstStatusMsg) contextValidateErrInfo(ctx context.Context, formats s
 			if err := m.ErrInfo[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("errInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("errInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -860,6 +908,8 @@ func (m *AppInstStatusMsg) contextValidateMemorySummary(ctx context.Context, for
 		if err := m.MemorySummary.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("memorySummary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("memorySummary")
 			}
 			return err
 		}
@@ -876,6 +926,8 @@ func (m *AppInstStatusMsg) contextValidateNetCounterList(ctx context.Context, fo
 			if err := m.NetCounterList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("netCounterList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("netCounterList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -894,6 +946,8 @@ func (m *AppInstStatusMsg) contextValidateNetStatusList(ctx context.Context, for
 			if err := m.NetStatusList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("netStatusList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("netStatusList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -910,6 +964,8 @@ func (m *AppInstStatusMsg) contextValidateRunState(ctx context.Context, formats 
 		if err := m.RunState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -926,6 +982,8 @@ func (m *AppInstStatusMsg) contextValidateSwInfo(ctx context.Context, formats st
 			if err := m.SwInfo[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("swInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("swInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -942,6 +1000,8 @@ func (m *AppInstStatusMsg) contextValidateSwState(ctx context.Context, formats s
 		if err := m.SwState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("swState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("swState")
 			}
 			return err
 		}

--- a/swagger_models/app_inst_status_summary_msg.go
+++ b/swagger_models/app_inst_status_summary_msg.go
@@ -179,6 +179,8 @@ func (m *AppInstStatusSummaryMsg) validateCPU(formats strfmt.Registry) error {
 		if err := m.CPU.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Cpu")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Cpu")
 			}
 			return err
 		}
@@ -196,6 +198,8 @@ func (m *AppInstStatusSummaryMsg) validateMemory(formats strfmt.Registry) error 
 		if err := m.Memory.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Memory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Memory")
 			}
 			return err
 		}
@@ -213,6 +217,8 @@ func (m *AppInstStatusSummaryMsg) validateStorage(formats strfmt.Registry) error
 		if err := m.Storage.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Storage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Storage")
 			}
 			return err
 		}
@@ -230,6 +236,8 @@ func (m *AppInstStatusSummaryMsg) validateAdminState(formats strfmt.Registry) er
 		if err := m.AdminState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("adminState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("adminState")
 			}
 			return err
 		}
@@ -267,6 +275,8 @@ func (m *AppInstStatusSummaryMsg) validateAppType(formats strfmt.Registry) error
 		if err := m.AppType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -304,6 +314,8 @@ func (m *AppInstStatusSummaryMsg) validateDeploymentType(formats strfmt.Registry
 		if err := m.DeploymentType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}
@@ -353,6 +365,8 @@ func (m *AppInstStatusSummaryMsg) validateMemorySummary(formats strfmt.Registry)
 		if err := m.MemorySummary.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("memorySummary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("memorySummary")
 			}
 			return err
 		}
@@ -410,6 +424,8 @@ func (m *AppInstStatusSummaryMsg) validateRunState(formats strfmt.Registry) erro
 		if err := m.RunState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -427,6 +443,8 @@ func (m *AppInstStatusSummaryMsg) validateSwState(formats strfmt.Registry) error
 		if err := m.SwState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("swState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("swState")
 			}
 			return err
 		}
@@ -511,6 +529,8 @@ func (m *AppInstStatusSummaryMsg) contextValidateCPU(ctx context.Context, format
 		if err := m.CPU.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Cpu")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Cpu")
 			}
 			return err
 		}
@@ -525,6 +545,8 @@ func (m *AppInstStatusSummaryMsg) contextValidateMemory(ctx context.Context, for
 		if err := m.Memory.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Memory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Memory")
 			}
 			return err
 		}
@@ -539,6 +561,8 @@ func (m *AppInstStatusSummaryMsg) contextValidateStorage(ctx context.Context, fo
 		if err := m.Storage.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Storage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Storage")
 			}
 			return err
 		}
@@ -553,6 +577,8 @@ func (m *AppInstStatusSummaryMsg) contextValidateAdminState(ctx context.Context,
 		if err := m.AdminState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("adminState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("adminState")
 			}
 			return err
 		}
@@ -567,6 +593,8 @@ func (m *AppInstStatusSummaryMsg) contextValidateAppType(ctx context.Context, fo
 		if err := m.AppType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -581,6 +609,8 @@ func (m *AppInstStatusSummaryMsg) contextValidateDeploymentType(ctx context.Cont
 		if err := m.DeploymentType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}
@@ -604,6 +634,8 @@ func (m *AppInstStatusSummaryMsg) contextValidateMemorySummary(ctx context.Conte
 		if err := m.MemorySummary.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("memorySummary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("memorySummary")
 			}
 			return err
 		}
@@ -618,6 +650,8 @@ func (m *AppInstStatusSummaryMsg) contextValidateRunState(ctx context.Context, f
 		if err := m.RunState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -632,6 +666,8 @@ func (m *AppInstStatusSummaryMsg) contextValidateSwState(ctx context.Context, fo
 		if err := m.SwState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("swState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("swState")
 			}
 			return err
 		}

--- a/swagger_models/app_instance.go
+++ b/swagger_models/app_instance.go
@@ -278,6 +278,8 @@ func (m *AppInstance) validateAppType(formats strfmt.Registry) error {
 		if err := m.AppType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -315,6 +317,8 @@ func (m *AppInstance) validateCustomConfig(formats strfmt.Registry) error {
 		if err := m.CustomConfig.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("customConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("customConfig")
 			}
 			return err
 		}
@@ -332,6 +336,8 @@ func (m *AppInstance) validateDeploymentType(formats strfmt.Registry) error {
 		if err := m.DeploymentType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}
@@ -388,6 +394,8 @@ func (m *AppInstance) validateDrives(formats strfmt.Registry) error {
 			if err := m.Drives[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("drives" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("drives" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -425,6 +433,8 @@ func (m *AppInstance) validateInterfaces(formats strfmt.Registry) error {
 			if err := m.Interfaces[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("interfaces" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("interfaces" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -444,6 +454,8 @@ func (m *AppInstance) validateLogs(formats strfmt.Registry) error {
 		if err := m.Logs.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("logs")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("logs")
 			}
 			return err
 		}
@@ -461,6 +473,8 @@ func (m *AppInstance) validateManifestInfo(formats strfmt.Registry) error {
 		if err := m.ManifestInfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("manifestInfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("manifestInfo")
 			}
 			return err
 		}
@@ -508,6 +522,8 @@ func (m *AppInstance) validatePurge(formats strfmt.Registry) error {
 		if err := m.Purge.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("purge")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("purge")
 			}
 			return err
 		}
@@ -525,6 +541,8 @@ func (m *AppInstance) validateRefresh(formats strfmt.Registry) error {
 		if err := m.Refresh.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("refresh")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("refresh")
 			}
 			return err
 		}
@@ -542,6 +560,8 @@ func (m *AppInstance) validateRestart(formats strfmt.Registry) error {
 		if err := m.Restart.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("restart")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("restart")
 			}
 			return err
 		}
@@ -559,6 +579,8 @@ func (m *AppInstance) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -597,6 +619,8 @@ func (m *AppInstance) validateVminfo(formats strfmt.Registry) error {
 		if err := m.Vminfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("vminfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("vminfo")
 			}
 			return err
 		}
@@ -673,6 +697,8 @@ func (m *AppInstance) contextValidateAppType(ctx context.Context, formats strfmt
 		if err := m.AppType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -687,6 +713,8 @@ func (m *AppInstance) contextValidateCustomConfig(ctx context.Context, formats s
 		if err := m.CustomConfig.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("customConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("customConfig")
 			}
 			return err
 		}
@@ -701,6 +729,8 @@ func (m *AppInstance) contextValidateDeploymentType(ctx context.Context, formats
 		if err := m.DeploymentType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}
@@ -717,6 +747,8 @@ func (m *AppInstance) contextValidateDrives(ctx context.Context, formats strfmt.
 			if err := m.Drives[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("drives" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("drives" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -744,6 +776,8 @@ func (m *AppInstance) contextValidateInterfaces(ctx context.Context, formats str
 			if err := m.Interfaces[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("interfaces" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("interfaces" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -760,6 +794,8 @@ func (m *AppInstance) contextValidateLogs(ctx context.Context, formats strfmt.Re
 		if err := m.Logs.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("logs")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("logs")
 			}
 			return err
 		}
@@ -774,6 +810,8 @@ func (m *AppInstance) contextValidateManifestInfo(ctx context.Context, formats s
 		if err := m.ManifestInfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("manifestInfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("manifestInfo")
 			}
 			return err
 		}
@@ -788,6 +826,8 @@ func (m *AppInstance) contextValidatePurge(ctx context.Context, formats strfmt.R
 		if err := m.Purge.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("purge")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("purge")
 			}
 			return err
 		}
@@ -802,6 +842,8 @@ func (m *AppInstance) contextValidateRefresh(ctx context.Context, formats strfmt
 		if err := m.Refresh.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("refresh")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("refresh")
 			}
 			return err
 		}
@@ -816,6 +858,8 @@ func (m *AppInstance) contextValidateRestart(ctx context.Context, formats strfmt
 		if err := m.Restart.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("restart")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("restart")
 			}
 			return err
 		}
@@ -830,6 +874,8 @@ func (m *AppInstance) contextValidateRevision(ctx context.Context, formats strfm
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -844,6 +890,8 @@ func (m *AppInstance) contextValidateVminfo(ctx context.Context, formats strfmt.
 		if err := m.Vminfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("vminfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("vminfo")
 			}
 			return err
 		}

--- a/swagger_models/app_instance_deploy.go
+++ b/swagger_models/app_instance_deploy.go
@@ -55,6 +55,8 @@ func (m *AppInstanceDeploy) validateInstanceConfig(formats strfmt.Registry) erro
 			if err := m.InstanceConfig[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("instanceConfig" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("instanceConfig" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *AppInstanceDeploy) contextValidateInstanceConfig(ctx context.Context, f
 			if err := m.InstanceConfig[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("instanceConfig" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("instanceConfig" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/app_instance_logs_query_response.go
+++ b/swagger_models/app_instance_logs_query_response.go
@@ -66,6 +66,8 @@ func (m *AppInstanceLogsQueryResponse) validateList(formats strfmt.Registry) err
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -85,6 +87,8 @@ func (m *AppInstanceLogsQueryResponse) validateNext(formats strfmt.Registry) err
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -119,6 +123,8 @@ func (m *AppInstanceLogsQueryResponse) contextValidateList(ctx context.Context, 
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -135,6 +141,8 @@ func (m *AppInstanceLogsQueryResponse) contextValidateNext(ctx context.Context, 
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}

--- a/swagger_models/app_instance_logs_response.go
+++ b/swagger_models/app_instance_logs_response.go
@@ -55,6 +55,8 @@ func (m *AppInstanceLogsResponse) validateContent(formats strfmt.Registry) error
 		if err := m.Content.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("content")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("content")
 			}
 			return err
 		}
@@ -72,6 +74,8 @@ func (m *AppInstanceLogsResponse) validateResult(formats strfmt.Registry) error 
 		if err := m.Result.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("result")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *AppInstanceLogsResponse) contextValidateContent(ctx context.Context, fo
 		if err := m.Content.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("content")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("content")
 			}
 			return err
 		}
@@ -118,6 +124,8 @@ func (m *AppInstanceLogsResponse) contextValidateResult(ctx context.Context, for
 		if err := m.Result.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("result")
 			}
 			return err
 		}

--- a/swagger_models/app_instances.go
+++ b/swagger_models/app_instances.go
@@ -68,6 +68,8 @@ func (m *AppInstances) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *AppInstances) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *AppInstances) validateSummaryByState(formats strfmt.Registry) error {
 		if err := m.SummaryByState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *AppInstances) contextValidateList(ctx context.Context, formats strfmt.R
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -158,6 +166,8 @@ func (m *AppInstances) contextValidateNext(ctx context.Context, formats strfmt.R
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *AppInstances) contextValidateSummaryByState(ctx context.Context, format
 		if err := m.SummaryByState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}

--- a/swagger_models/app_interface.go
+++ b/swagger_models/app_interface.go
@@ -175,6 +175,8 @@ func (m *AppInterface) validateAcls(formats strfmt.Registry) error {
 			if err := m.Acls[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("acls" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("acls" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -204,6 +206,8 @@ func (m *AppInterface) validateEidregister(formats strfmt.Registry) error {
 		if err := m.Eidregister.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("eidregister")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("eidregister")
 			}
 			return err
 		}
@@ -240,6 +244,8 @@ func (m *AppInterface) validateIo(formats strfmt.Registry) error {
 		if err := m.Io.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("io")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("io")
 			}
 			return err
 		}
@@ -314,6 +320,8 @@ func (m *AppInterface) contextValidateAcls(ctx context.Context, formats strfmt.R
 			if err := m.Acls[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("acls" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("acls" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -330,6 +338,8 @@ func (m *AppInterface) contextValidateEidregister(ctx context.Context, formats s
 		if err := m.Eidregister.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("eidregister")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("eidregister")
 			}
 			return err
 		}
@@ -344,6 +354,8 @@ func (m *AppInterface) contextValidateIo(ctx context.Context, formats strfmt.Reg
 		if err := m.Io.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("io")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("io")
 			}
 			return err
 		}

--- a/swagger_models/app_naming_scheme.go
+++ b/swagger_models/app_naming_scheme.go
@@ -23,8 +23,12 @@ import (
 type AppNamingScheme string
 
 func NewAppNamingScheme(value AppNamingScheme) *AppNamingScheme {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AppNamingScheme.
+func (m AppNamingScheme) Pointer() *AppNamingScheme {
+	return &m
 }
 
 const (

--- a/swagger_models/app_policy.go
+++ b/swagger_models/app_policy.go
@@ -59,6 +59,8 @@ func (m *AppPolicy) validateApps(formats strfmt.Registry) error {
 			if err := m.Apps[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("apps" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("apps" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -91,6 +93,8 @@ func (m *AppPolicy) contextValidateApps(ctx context.Context, formats strfmt.Regi
 			if err := m.Apps[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("apps" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("apps" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/app_status_from_t_p_controller.go
+++ b/swagger_models/app_status_from_t_p_controller.go
@@ -67,6 +67,8 @@ func (m *AppStatusFromTPController) validateAzureStatus(formats strfmt.Registry)
 		if err := m.AzureStatus.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("azureStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("azureStatus")
 			}
 			return err
 		}
@@ -84,6 +86,8 @@ func (m *AppStatusFromTPController) validateType(formats strfmt.Registry) error 
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -116,6 +120,8 @@ func (m *AppStatusFromTPController) contextValidateAzureStatus(ctx context.Conte
 		if err := m.AzureStatus.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("azureStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("azureStatus")
 			}
 			return err
 		}
@@ -130,6 +136,8 @@ func (m *AppStatusFromTPController) contextValidateType(ctx context.Context, for
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/app_summary.go
+++ b/swagger_models/app_summary.go
@@ -146,6 +146,8 @@ func (m *AppSummary) validateManifestJSON(formats strfmt.Registry) error {
 		if err := m.ManifestJSON.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("manifestJSON")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("manifestJSON")
 			}
 			return err
 		}
@@ -183,6 +185,8 @@ func (m *AppSummary) validateOriginType(formats strfmt.Registry) error {
 		if err := m.OriginType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -200,6 +204,8 @@ func (m *AppSummary) validateParentDetail(formats strfmt.Registry) error {
 		if err := m.ParentDetail.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("parentDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("parentDetail")
 			}
 			return err
 		}
@@ -282,6 +288,8 @@ func (m *AppSummary) contextValidateManifestJSON(ctx context.Context, formats st
 		if err := m.ManifestJSON.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("manifestJSON")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("manifestJSON")
 			}
 			return err
 		}
@@ -296,6 +304,8 @@ func (m *AppSummary) contextValidateOriginType(ctx context.Context, formats strf
 		if err := m.OriginType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -310,6 +320,8 @@ func (m *AppSummary) contextValidateParentDetail(ctx context.Context, formats st
 		if err := m.ParentDetail.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("parentDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("parentDetail")
 			}
 			return err
 		}

--- a/swagger_models/app_type.go
+++ b/swagger_models/app_type.go
@@ -23,8 +23,12 @@ import (
 type AppType string
 
 func NewAppType(value AppType) *AppType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AppType.
+func (m AppType) Pointer() *AppType {
+	return &m
 }
 
 const (

--- a/swagger_models/apps.go
+++ b/swagger_models/apps.go
@@ -75,6 +75,8 @@ func (m *Apps) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -94,6 +96,8 @@ func (m *Apps) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -111,6 +115,8 @@ func (m *Apps) validateSummaryByCategory(formats strfmt.Registry) error {
 		if err := m.SummaryByCategory.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByCategory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByCategory")
 			}
 			return err
 		}
@@ -128,6 +134,8 @@ func (m *Apps) validateSummaryByOrigin(formats strfmt.Registry) error {
 		if err := m.SummaryByOrigin.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByOrigin")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByOrigin")
 			}
 			return err
 		}
@@ -170,6 +178,8 @@ func (m *Apps) contextValidateList(ctx context.Context, formats strfmt.Registry)
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -186,6 +196,8 @@ func (m *Apps) contextValidateNext(ctx context.Context, formats strfmt.Registry)
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -200,6 +212,8 @@ func (m *Apps) contextValidateSummaryByCategory(ctx context.Context, formats str
 		if err := m.SummaryByCategory.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByCategory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByCategory")
 			}
 			return err
 		}
@@ -214,6 +228,8 @@ func (m *Apps) contextValidateSummaryByOrigin(ctx context.Context, formats strfm
 		if err := m.SummaryByOrigin.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByOrigin")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByOrigin")
 			}
 			return err
 		}

--- a/swagger_models/artifact.go
+++ b/swagger_models/artifact.go
@@ -111,6 +111,8 @@ func (m *Artifact) validateStatus(formats strfmt.Registry) error {
 		if err := m.Status.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}
@@ -169,6 +171,8 @@ func (m *Artifact) contextValidateStatus(ctx context.Context, formats strfmt.Reg
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}

--- a/swagger_models/artifact_list.go
+++ b/swagger_models/artifact_list.go
@@ -70,6 +70,8 @@ func (m *ArtifactList) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -89,6 +91,8 @@ func (m *ArtifactList) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -106,6 +110,8 @@ func (m *ArtifactList) validateSummary(formats strfmt.Registry) error {
 		if err := m.Summary.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summary")
 			}
 			return err
 		}
@@ -144,6 +150,8 @@ func (m *ArtifactList) contextValidateList(ctx context.Context, formats strfmt.R
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -160,6 +168,8 @@ func (m *ArtifactList) contextValidateNext(ctx context.Context, formats strfmt.R
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -174,6 +184,8 @@ func (m *ArtifactList) contextValidateSummary(ctx context.Context, formats strfm
 		if err := m.Summary.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summary")
 			}
 			return err
 		}

--- a/swagger_models/attest_policy_type.go
+++ b/swagger_models/attest_policy_type.go
@@ -24,8 +24,12 @@ import (
 type AttestPolicyType string
 
 func NewAttestPolicyType(value AttestPolicyType) *AttestPolicyType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AttestPolicyType.
+func (m AttestPolicyType) Pointer() *AttestPolicyType {
+	return &m
 }
 
 const (

--- a/swagger_models/attest_state.go
+++ b/swagger_models/attest_state.go
@@ -23,8 +23,12 @@ import (
 type AttestState string
 
 func NewAttestState(value AttestState) *AttestState {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AttestState.
+func (m AttestState) Pointer() *AttestState {
+	return &m
 }
 
 const (

--- a/swagger_models/attestation_policy.go
+++ b/swagger_models/attestation_policy.go
@@ -78,6 +78,8 @@ func (m *AttestationPolicy) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -119,6 +121,8 @@ func (m *AttestationPolicy) contextValidateType(ctx context.Context, formats str
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/auth_profile_type.go
+++ b/swagger_models/auth_profile_type.go
@@ -23,8 +23,12 @@ import (
 type AuthProfileType string
 
 func NewAuthProfileType(value AuthProfileType) *AuthProfileType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AuthProfileType.
+func (m AuthProfileType) Pointer() *AuthProfileType {
+	return &m
 }
 
 const (

--- a/swagger_models/auth_type.go
+++ b/swagger_models/auth_type.go
@@ -23,8 +23,12 @@ import (
 type AuthType string
 
 func NewAuthType(value AuthType) *AuthType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated AuthType.
+func (m AuthType) Pointer() *AuthType {
+	return &m
 }
 
 const (

--- a/swagger_models/authorization_profile.go
+++ b/swagger_models/authorization_profile.go
@@ -205,6 +205,8 @@ func (m *AuthorizationProfile) validateOauthProfile(formats strfmt.Registry) err
 		if err := m.OauthProfile.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("oauthProfile")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("oauthProfile")
 			}
 			return err
 		}
@@ -222,6 +224,8 @@ func (m *AuthorizationProfile) validateProfileType(formats strfmt.Registry) erro
 		if err := m.ProfileType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("profileType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("profileType")
 			}
 			return err
 		}
@@ -239,6 +243,8 @@ func (m *AuthorizationProfile) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -277,6 +283,8 @@ func (m *AuthorizationProfile) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -330,6 +338,8 @@ func (m *AuthorizationProfile) contextValidateOauthProfile(ctx context.Context, 
 		if err := m.OauthProfile.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("oauthProfile")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("oauthProfile")
 			}
 			return err
 		}
@@ -344,6 +354,8 @@ func (m *AuthorizationProfile) contextValidateProfileType(ctx context.Context, f
 		if err := m.ProfileType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("profileType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("profileType")
 			}
 			return err
 		}
@@ -358,6 +370,8 @@ func (m *AuthorizationProfile) contextValidateRevision(ctx context.Context, form
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -372,6 +386,8 @@ func (m *AuthorizationProfile) contextValidateType(ctx context.Context, formats 
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/authorization_profiles.go
+++ b/swagger_models/authorization_profiles.go
@@ -68,6 +68,8 @@ func (m *AuthorizationProfiles) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *AuthorizationProfiles) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *AuthorizationProfiles) validateSummaryByState(formats strfmt.Registry) 
 		if err := m.SummaryByState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *AuthorizationProfiles) contextValidateList(ctx context.Context, formats
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -158,6 +166,8 @@ func (m *AuthorizationProfiles) contextValidateNext(ctx context.Context, formats
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *AuthorizationProfiles) contextValidateSummaryByState(ctx context.Contex
 		if err := m.SummaryByState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}

--- a/swagger_models/azure_dev_status_detail.go
+++ b/swagger_models/azure_dev_status_detail.go
@@ -63,6 +63,8 @@ func (m *AzureDevStatusDetail) validateTwin(formats strfmt.Registry) error {
 		if err := m.Twin.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("twin")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("twin")
 			}
 			return err
 		}
@@ -91,6 +93,8 @@ func (m *AzureDevStatusDetail) contextValidateTwin(ctx context.Context, formats 
 		if err := m.Twin.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("twin")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("twin")
 			}
 			return err
 		}

--- a/swagger_models/azure_policy.go
+++ b/swagger_models/azure_policy.go
@@ -109,6 +109,8 @@ func (m *AzurePolicy) validateAzureResourceAndServices(formats strfmt.Registry) 
 		if err := m.AzureResourceAndServices.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("azureResourceAndServices")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("azureResourceAndServices")
 			}
 			return err
 		}
@@ -126,6 +128,8 @@ func (m *AzurePolicy) validateCertificate(formats strfmt.Registry) error {
 		if err := m.Certificate.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("certificate")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("certificate")
 			}
 			return err
 		}
@@ -167,6 +171,8 @@ func (m *AzurePolicy) contextValidateAzureResourceAndServices(ctx context.Contex
 		if err := m.AzureResourceAndServices.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("azureResourceAndServices")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("azureResourceAndServices")
 			}
 			return err
 		}
@@ -181,6 +187,8 @@ func (m *AzurePolicy) contextValidateCertificate(ctx context.Context, formats st
 		if err := m.Certificate.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("certificate")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("certificate")
 			}
 			return err
 		}

--- a/swagger_models/azure_resource_and_service_detail.go
+++ b/swagger_models/azure_resource_and_service_detail.go
@@ -63,6 +63,8 @@ func (m *AzureResourceAndServiceDetail) validateSKU(formats strfmt.Registry) err
 		if err := m.SKU.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("SKU")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("SKU")
 			}
 			return err
 		}
@@ -91,6 +93,8 @@ func (m *AzureResourceAndServiceDetail) contextValidateSKU(ctx context.Context, 
 		if err := m.SKU.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("SKU")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("SKU")
 			}
 			return err
 		}

--- a/swagger_models/azure_resource_and_services.go
+++ b/swagger_models/azure_resource_and_services.go
@@ -70,6 +70,8 @@ func (m *AzureResourceAndServices) validateDpsService(formats strfmt.Registry) e
 		if err := m.DpsService.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dpsService")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dpsService")
 			}
 			return err
 		}
@@ -93,6 +95,8 @@ func (m *AzureResourceAndServices) validateIotHubService(formats strfmt.Registry
 			if err := m.IotHubService[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("iotHubService" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("iotHubService" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -118,6 +122,8 @@ func (m *AzureResourceAndServices) validateResourceGroup(formats strfmt.Registry
 			if err := m.ResourceGroup[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("resourceGroup" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("resourceGroup" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -156,6 +162,8 @@ func (m *AzureResourceAndServices) contextValidateDpsService(ctx context.Context
 		if err := m.DpsService.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dpsService")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dpsService")
 			}
 			return err
 		}
@@ -172,6 +180,8 @@ func (m *AzureResourceAndServices) contextValidateIotHubService(ctx context.Cont
 			if err := m.IotHubService[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("iotHubService" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("iotHubService" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -190,6 +200,8 @@ func (m *AzureResourceAndServices) contextValidateResourceGroup(ctx context.Cont
 			if err := m.ResourceGroup[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("resourceGroup" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("resourceGroup" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/azure_status.go
+++ b/swagger_models/azure_status.go
@@ -48,6 +48,8 @@ func (m *AzureStatus) validateAzureDevStatus(formats strfmt.Registry) error {
 		if err := m.AzureDevStatus.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("azureDevStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("azureDevStatus")
 			}
 			return err
 		}
@@ -76,6 +78,8 @@ func (m *AzureStatus) contextValidateAzureDevStatus(ctx context.Context, formats
 		if err := m.AzureDevStatus.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("azureDevStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("azureDevStatus")
 			}
 			return err
 		}

--- a/swagger_models/baseos_update.go
+++ b/swagger_models/baseos_update.go
@@ -48,6 +48,8 @@ func (m *BaseosUpdate) validateBaseimage(formats strfmt.Registry) error {
 		if err := m.Baseimage.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("baseimage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("baseimage")
 			}
 			return err
 		}
@@ -76,6 +78,8 @@ func (m *BaseosUpdate) contextValidateBaseimage(ctx context.Context, formats str
 		if err := m.Baseimage.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("baseimage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("baseimage")
 			}
 			return err
 		}

--- a/swagger_models/blob_info.go
+++ b/swagger_models/blob_info.go
@@ -75,6 +75,8 @@ func (m *BlobInfo) validateState(formats strfmt.Registry) error {
 		if err := m.State.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("State")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("State")
 			}
 			return err
 		}
@@ -92,6 +94,8 @@ func (m *BlobInfo) validateErrInfo(formats strfmt.Registry) error {
 		if err := m.ErrInfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("errInfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("errInfo")
 			}
 			return err
 		}
@@ -109,6 +113,8 @@ func (m *BlobInfo) validateResource(formats strfmt.Registry) error {
 		if err := m.Resource.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("resource")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("resource")
 			}
 			return err
 		}
@@ -126,6 +132,8 @@ func (m *BlobInfo) validateUsage(formats strfmt.Registry) error {
 		if err := m.Usage.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("usage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("usage")
 			}
 			return err
 		}
@@ -166,6 +174,8 @@ func (m *BlobInfo) contextValidateState(ctx context.Context, formats strfmt.Regi
 		if err := m.State.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("State")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("State")
 			}
 			return err
 		}
@@ -180,6 +190,8 @@ func (m *BlobInfo) contextValidateErrInfo(ctx context.Context, formats strfmt.Re
 		if err := m.ErrInfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("errInfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("errInfo")
 			}
 			return err
 		}
@@ -194,6 +206,8 @@ func (m *BlobInfo) contextValidateResource(ctx context.Context, formats strfmt.R
 		if err := m.Resource.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("resource")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("resource")
 			}
 			return err
 		}
@@ -208,6 +222,8 @@ func (m *BlobInfo) contextValidateUsage(ctx context.Context, formats strfmt.Regi
 		if err := m.Usage.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("usage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("usage")
 			}
 			return err
 		}

--- a/swagger_models/blob_status.go
+++ b/swagger_models/blob_status.go
@@ -57,6 +57,8 @@ func (m *BlobStatus) validateSwState(formats strfmt.Registry) error {
 		if err := m.SwState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("swState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("swState")
 			}
 			return err
 		}
@@ -85,6 +87,8 @@ func (m *BlobStatus) contextValidateSwState(ctx context.Context, formats strfmt.
 		if err := m.SwState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("swState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("swState")
 			}
 			return err
 		}

--- a/swagger_models/bulk_config.go
+++ b/swagger_models/bulk_config.go
@@ -89,6 +89,8 @@ func (m *BulkConfig) validateBaseosUpdate(formats strfmt.Registry) error {
 		if err := m.BaseosUpdate.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("baseosUpdate")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("baseosUpdate")
 			}
 			return err
 		}
@@ -106,6 +108,8 @@ func (m *BulkConfig) validateBundleImport(formats strfmt.Registry) error {
 		if err := m.BundleImport.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("bundleImport")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("bundleImport")
 			}
 			return err
 		}
@@ -123,6 +127,8 @@ func (m *BulkConfig) validateInstanceDeploy(formats strfmt.Registry) error {
 		if err := m.InstanceDeploy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("instanceDeploy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("instanceDeploy")
 			}
 			return err
 		}
@@ -140,6 +146,8 @@ func (m *BulkConfig) validateInstanceRefreshAndPurge(formats strfmt.Registry) er
 		if err := m.InstanceRefreshAndPurge.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("instanceRefreshAndPurge")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("instanceRefreshAndPurge")
 			}
 			return err
 		}
@@ -157,6 +165,8 @@ func (m *BulkConfig) validateModelImport(formats strfmt.Registry) error {
 		if err := m.ModelImport.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("modelImport")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("modelImport")
 			}
 			return err
 		}
@@ -174,6 +184,8 @@ func (m *BulkConfig) validateSelectionCriteria(formats strfmt.Registry) error {
 		if err := m.SelectionCriteria.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("selectionCriteria")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("selectionCriteria")
 			}
 			return err
 		}
@@ -222,6 +234,8 @@ func (m *BulkConfig) contextValidateBaseosUpdate(ctx context.Context, formats st
 		if err := m.BaseosUpdate.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("baseosUpdate")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("baseosUpdate")
 			}
 			return err
 		}
@@ -236,6 +250,8 @@ func (m *BulkConfig) contextValidateBundleImport(ctx context.Context, formats st
 		if err := m.BundleImport.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("bundleImport")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("bundleImport")
 			}
 			return err
 		}
@@ -250,6 +266,8 @@ func (m *BulkConfig) contextValidateInstanceDeploy(ctx context.Context, formats 
 		if err := m.InstanceDeploy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("instanceDeploy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("instanceDeploy")
 			}
 			return err
 		}
@@ -264,6 +282,8 @@ func (m *BulkConfig) contextValidateInstanceRefreshAndPurge(ctx context.Context,
 		if err := m.InstanceRefreshAndPurge.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("instanceRefreshAndPurge")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("instanceRefreshAndPurge")
 			}
 			return err
 		}
@@ -278,6 +298,8 @@ func (m *BulkConfig) contextValidateModelImport(ctx context.Context, formats str
 		if err := m.ModelImport.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("modelImport")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("modelImport")
 			}
 			return err
 		}
@@ -292,6 +314,8 @@ func (m *BulkConfig) contextValidateSelectionCriteria(ctx context.Context, forma
 		if err := m.SelectionCriteria.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("selectionCriteria")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("selectionCriteria")
 			}
 			return err
 		}

--- a/swagger_models/bulk_instance_config.go
+++ b/swagger_models/bulk_instance_config.go
@@ -66,6 +66,8 @@ func (m *BulkInstanceConfig) validateAppInstanceConfig(formats strfmt.Registry) 
 		if err := m.AppInstanceConfig.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appInstanceConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appInstanceConfig")
 			}
 			return err
 		}
@@ -88,6 +90,8 @@ func (m *BulkInstanceConfig) validateNetInstanceConfig(formats strfmt.Registry) 
 			if err := m.NetInstanceConfig[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("netInstanceConfig" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("netInstanceConfig" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -107,6 +111,8 @@ func (m *BulkInstanceConfig) validateNetInstanceDetail(formats strfmt.Registry) 
 		if err := m.NetInstanceDetail.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("netInstanceDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("netInstanceDetail")
 			}
 			return err
 		}
@@ -143,6 +149,8 @@ func (m *BulkInstanceConfig) contextValidateAppInstanceConfig(ctx context.Contex
 		if err := m.AppInstanceConfig.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appInstanceConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appInstanceConfig")
 			}
 			return err
 		}
@@ -159,6 +167,8 @@ func (m *BulkInstanceConfig) contextValidateNetInstanceConfig(ctx context.Contex
 			if err := m.NetInstanceConfig[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("netInstanceConfig" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("netInstanceConfig" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -175,6 +185,8 @@ func (m *BulkInstanceConfig) contextValidateNetInstanceDetail(ctx context.Contex
 		if err := m.NetInstanceDetail.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("netInstanceDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("netInstanceDetail")
 			}
 			return err
 		}

--- a/swagger_models/bulk_service.go
+++ b/swagger_models/bulk_service.go
@@ -23,8 +23,12 @@ import (
 type BulkService string
 
 func NewBulkService(value BulkService) *BulkService {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated BulkService.
+func (m BulkService) Pointer() *BulkService {
+	return &m
 }
 
 const (

--- a/swagger_models/bundle_import.go
+++ b/swagger_models/bundle_import.go
@@ -54,6 +54,8 @@ func (m *BundleImport) validateBundleConfig(formats strfmt.Registry) error {
 			if err := m.BundleConfig[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("bundleConfig" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("bundleConfig" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -86,6 +88,8 @@ func (m *BundleImport) contextValidateBundleConfig(ctx context.Context, formats 
 			if err := m.BundleConfig[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("bundleConfig" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("bundleConfig" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/certificate.go
+++ b/swagger_models/certificate.go
@@ -143,6 +143,8 @@ func (m *Certificate) validateEcdsaEncryption(formats strfmt.Registry) error {
 		if err := m.EcdsaEncryption.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ecdsaEncryption")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ecdsaEncryption")
 			}
 			return err
 		}
@@ -160,6 +162,8 @@ func (m *Certificate) validateIssuer(formats strfmt.Registry) error {
 		if err := m.Issuer.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("issuer")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("issuer")
 			}
 			return err
 		}
@@ -177,6 +181,8 @@ func (m *Certificate) validateRsaEcryption(formats strfmt.Registry) error {
 		if err := m.RsaEcryption.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("rsaEcryption")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("rsaEcryption")
 			}
 			return err
 		}
@@ -194,6 +200,8 @@ func (m *Certificate) validateSanValues(formats strfmt.Registry) error {
 		if err := m.SanValues.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("sanValues")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sanValues")
 			}
 			return err
 		}
@@ -211,6 +219,8 @@ func (m *Certificate) validateSubject(formats strfmt.Registry) error {
 		if err := m.Subject.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("subject")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("subject")
 			}
 			return err
 		}
@@ -279,6 +289,8 @@ func (m *Certificate) contextValidateEcdsaEncryption(ctx context.Context, format
 		if err := m.EcdsaEncryption.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ecdsaEncryption")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ecdsaEncryption")
 			}
 			return err
 		}
@@ -293,6 +305,8 @@ func (m *Certificate) contextValidateIssuer(ctx context.Context, formats strfmt.
 		if err := m.Issuer.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("issuer")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("issuer")
 			}
 			return err
 		}
@@ -307,6 +321,8 @@ func (m *Certificate) contextValidateRsaEcryption(ctx context.Context, formats s
 		if err := m.RsaEcryption.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("rsaEcryption")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("rsaEcryption")
 			}
 			return err
 		}
@@ -321,6 +337,8 @@ func (m *Certificate) contextValidateSanValues(ctx context.Context, formats strf
 		if err := m.SanValues.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("sanValues")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sanValues")
 			}
 			return err
 		}
@@ -335,6 +353,8 @@ func (m *Certificate) contextValidateSubject(ctx context.Context, formats strfmt
 		if err := m.Subject.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("subject")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("subject")
 			}
 			return err
 		}

--- a/swagger_models/certificate_chain.go
+++ b/swagger_models/certificate_chain.go
@@ -54,6 +54,8 @@ func (m *CertificateChain) validateCertificates(formats strfmt.Registry) error {
 			if err := m.Certificates[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("certificates" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("certificates" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -86,6 +88,8 @@ func (m *CertificateChain) contextValidateCertificates(ctx context.Context, form
 			if err := m.Certificates[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("certificates" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("certificates" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/classification_response.go
+++ b/swagger_models/classification_response.go
@@ -54,6 +54,8 @@ func (m *ClassificationResponse) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -86,6 +88,8 @@ func (m *ClassificationResponse) contextValidateList(ctx context.Context, format
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/cloud_version_resp.go
+++ b/swagger_models/cloud_version_resp.go
@@ -55,6 +55,8 @@ func (m *CloudVersionResp) validateResult(formats strfmt.Registry) error {
 		if err := m.Result.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("result")
 			}
 			return err
 		}
@@ -72,6 +74,8 @@ func (m *CloudVersionResp) validateVersion(formats strfmt.Registry) error {
 		if err := m.Version.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("version")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("version")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *CloudVersionResp) contextValidateResult(ctx context.Context, formats st
 		if err := m.Result.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("result")
 			}
 			return err
 		}
@@ -118,6 +124,8 @@ func (m *CloudVersionResp) contextValidateVersion(ctx context.Context, formats s
 		if err := m.Version.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("version")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("version")
 			}
 			return err
 		}

--- a/swagger_models/cluster_policy.go
+++ b/swagger_models/cluster_policy.go
@@ -90,6 +90,8 @@ func (m *ClusterPolicy) validateClusterConfig(formats strfmt.Registry) error {
 		if err := m.ClusterConfig.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("clusterConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("clusterConfig")
 			}
 			return err
 		}
@@ -125,6 +127,8 @@ func (m *ClusterPolicy) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -157,6 +161,8 @@ func (m *ClusterPolicy) contextValidateClusterConfig(ctx context.Context, format
 		if err := m.ClusterConfig.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("clusterConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("clusterConfig")
 			}
 			return err
 		}
@@ -171,6 +177,8 @@ func (m *ClusterPolicy) contextValidateType(ctx context.Context, formats strfmt.
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/cluster_type.go
+++ b/swagger_models/cluster_type.go
@@ -23,8 +23,12 @@ import (
 type ClusterType string
 
 func NewClusterType(value ClusterType) *ClusterType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ClusterType.
+func (m ClusterType) Pointer() *ClusterType {
+	return &m
 }
 
 const (

--- a/swagger_models/common_hash_algorithm.go
+++ b/swagger_models/common_hash_algorithm.go
@@ -23,8 +23,12 @@ import (
 type CommonHashAlgorithm string
 
 func NewCommonHashAlgorithm(value CommonHashAlgorithm) *CommonHashAlgorithm {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated CommonHashAlgorithm.
+func (m CommonHashAlgorithm) Pointer() *CommonHashAlgorithm {
+	return &m
 }
 
 const (

--- a/swagger_models/common_phy_io_member_usage.go
+++ b/swagger_models/common_phy_io_member_usage.go
@@ -29,8 +29,12 @@ import (
 type CommonPhyIoMemberUsage string
 
 func NewCommonPhyIoMemberUsage(value CommonPhyIoMemberUsage) *CommonPhyIoMemberUsage {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated CommonPhyIoMemberUsage.
+func (m CommonPhyIoMemberUsage) Pointer() *CommonPhyIoMemberUsage {
+	return &m
 }
 
 const (

--- a/swagger_models/common_phy_io_type.go
+++ b/swagger_models/common_phy_io_type.go
@@ -23,8 +23,12 @@ import (
 type CommonPhyIoType string
 
 func NewCommonPhyIoType(value CommonPhyIoType) *CommonPhyIoType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated CommonPhyIoType.
+func (m CommonPhyIoType) Pointer() *CommonPhyIoType {
+	return &m
 }
 
 const (

--- a/swagger_models/config_a_c_e.go
+++ b/swagger_models/config_a_c_e.go
@@ -78,6 +78,8 @@ func (m *ConfigACE) validateActions(formats strfmt.Registry) error {
 			if err := m.Actions[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("actions" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("actions" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -97,6 +99,8 @@ func (m *ConfigACE) validateDir(formats strfmt.Registry) error {
 		if err := m.Dir.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dir")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dir")
 			}
 			return err
 		}
@@ -119,6 +123,8 @@ func (m *ConfigACE) validateMatches(formats strfmt.Registry) error {
 			if err := m.Matches[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("matches" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("matches" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -159,6 +165,8 @@ func (m *ConfigACE) contextValidateActions(ctx context.Context, formats strfmt.R
 			if err := m.Actions[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("actions" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("actions" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -175,6 +183,8 @@ func (m *ConfigACE) contextValidateDir(ctx context.Context, formats strfmt.Regis
 		if err := m.Dir.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dir")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dir")
 			}
 			return err
 		}
@@ -191,6 +201,8 @@ func (m *ConfigACE) contextValidateMatches(ctx context.Context, formats strfmt.R
 			if err := m.Matches[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("matches" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("matches" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/config_a_c_e_direction.go
+++ b/swagger_models/config_a_c_e_direction.go
@@ -23,8 +23,12 @@ import (
 type ConfigACEDirection string
 
 func NewConfigACEDirection(value ConfigACEDirection) *ConfigACEDirection {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigACEDirection.
+func (m ConfigACEDirection) Pointer() *ConfigACEDirection {
+	return &m
 }
 
 const (

--- a/swagger_models/config_adapter.go
+++ b/swagger_models/config_adapter.go
@@ -53,6 +53,8 @@ func (m *ConfigAdapter) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -81,6 +83,8 @@ func (m *ConfigAdapter) contextValidateType(ctx context.Context, formats strfmt.
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/config_address_type.go
+++ b/swagger_models/config_address_type.go
@@ -23,8 +23,12 @@ import (
 type ConfigAddressType string
 
 func NewConfigAddressType(value ConfigAddressType) *ConfigAddressType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigAddressType.
+func (m ConfigAddressType) Pointer() *ConfigAddressType {
+	return &m
 }
 
 const (

--- a/swagger_models/config_app_instance_config.go
+++ b/swagger_models/config_app_instance_config.go
@@ -181,6 +181,8 @@ func (m *ConfigAppInstanceConfig) validateAdapters(formats strfmt.Registry) erro
 			if err := m.Adapters[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("adapters" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("adapters" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -200,6 +202,8 @@ func (m *ConfigAppInstanceConfig) validateCipherData(formats strfmt.Registry) er
 		if err := m.CipherData.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cipherData")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cipherData")
 			}
 			return err
 		}
@@ -222,6 +226,8 @@ func (m *ConfigAppInstanceConfig) validateDrives(formats strfmt.Registry) error 
 			if err := m.Drives[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("drives" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("drives" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -241,6 +247,8 @@ func (m *ConfigAppInstanceConfig) validateFixedresources(formats strfmt.Registry
 		if err := m.Fixedresources.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("fixedresources")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("fixedresources")
 			}
 			return err
 		}
@@ -263,6 +271,8 @@ func (m *ConfigAppInstanceConfig) validateInterfaces(formats strfmt.Registry) er
 			if err := m.Interfaces[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("interfaces" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("interfaces" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -282,6 +292,8 @@ func (m *ConfigAppInstanceConfig) validateMetaDataType(formats strfmt.Registry) 
 		if err := m.MetaDataType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("metaDataType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("metaDataType")
 			}
 			return err
 		}
@@ -299,6 +311,8 @@ func (m *ConfigAppInstanceConfig) validatePurge(formats strfmt.Registry) error {
 		if err := m.Purge.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("purge")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("purge")
 			}
 			return err
 		}
@@ -316,6 +330,8 @@ func (m *ConfigAppInstanceConfig) validateRestart(formats strfmt.Registry) error
 		if err := m.Restart.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("restart")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("restart")
 			}
 			return err
 		}
@@ -333,6 +349,8 @@ func (m *ConfigAppInstanceConfig) validateUuidandversion(formats strfmt.Registry
 		if err := m.Uuidandversion.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("uuidandversion")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("uuidandversion")
 			}
 			return err
 		}
@@ -355,6 +373,8 @@ func (m *ConfigAppInstanceConfig) validateVolumeRefList(formats strfmt.Registry)
 			if err := m.VolumeRefList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("volumeRefList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("volumeRefList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -423,6 +443,8 @@ func (m *ConfigAppInstanceConfig) contextValidateAdapters(ctx context.Context, f
 			if err := m.Adapters[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("adapters" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("adapters" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -439,6 +461,8 @@ func (m *ConfigAppInstanceConfig) contextValidateCipherData(ctx context.Context,
 		if err := m.CipherData.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cipherData")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cipherData")
 			}
 			return err
 		}
@@ -455,6 +479,8 @@ func (m *ConfigAppInstanceConfig) contextValidateDrives(ctx context.Context, for
 			if err := m.Drives[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("drives" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("drives" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -471,6 +497,8 @@ func (m *ConfigAppInstanceConfig) contextValidateFixedresources(ctx context.Cont
 		if err := m.Fixedresources.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("fixedresources")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("fixedresources")
 			}
 			return err
 		}
@@ -487,6 +515,8 @@ func (m *ConfigAppInstanceConfig) contextValidateInterfaces(ctx context.Context,
 			if err := m.Interfaces[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("interfaces" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("interfaces" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -503,6 +533,8 @@ func (m *ConfigAppInstanceConfig) contextValidateMetaDataType(ctx context.Contex
 		if err := m.MetaDataType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("metaDataType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("metaDataType")
 			}
 			return err
 		}
@@ -517,6 +549,8 @@ func (m *ConfigAppInstanceConfig) contextValidatePurge(ctx context.Context, form
 		if err := m.Purge.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("purge")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("purge")
 			}
 			return err
 		}
@@ -531,6 +565,8 @@ func (m *ConfigAppInstanceConfig) contextValidateRestart(ctx context.Context, fo
 		if err := m.Restart.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("restart")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("restart")
 			}
 			return err
 		}
@@ -545,6 +581,8 @@ func (m *ConfigAppInstanceConfig) contextValidateUuidandversion(ctx context.Cont
 		if err := m.Uuidandversion.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("uuidandversion")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("uuidandversion")
 			}
 			return err
 		}
@@ -561,6 +599,8 @@ func (m *ConfigAppInstanceConfig) contextValidateVolumeRefList(ctx context.Conte
 			if err := m.VolumeRefList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("volumeRefList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("volumeRefList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/config_base_o_s.go
+++ b/swagger_models/config_base_o_s.go
@@ -58,6 +58,8 @@ func (m *ConfigBaseOS) validateRetryUpdate(formats strfmt.Registry) error {
 		if err := m.RetryUpdate.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("retry_update")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("retry_update")
 			}
 			return err
 		}
@@ -86,6 +88,8 @@ func (m *ConfigBaseOS) contextValidateRetryUpdate(ctx context.Context, formats s
 		if err := m.RetryUpdate.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("retry_update")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("retry_update")
 			}
 			return err
 		}

--- a/swagger_models/config_base_o_s_config.go
+++ b/swagger_models/config_base_o_s_config.go
@@ -72,6 +72,8 @@ func (m *ConfigBaseOSConfig) validateDrives(formats strfmt.Registry) error {
 			if err := m.Drives[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("drives" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("drives" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -91,6 +93,8 @@ func (m *ConfigBaseOSConfig) validateUuidandversion(formats strfmt.Registry) err
 		if err := m.Uuidandversion.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("uuidandversion")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("uuidandversion")
 			}
 			return err
 		}
@@ -125,6 +129,8 @@ func (m *ConfigBaseOSConfig) contextValidateDrives(ctx context.Context, formats 
 			if err := m.Drives[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("drives" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("drives" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -141,6 +147,8 @@ func (m *ConfigBaseOSConfig) contextValidateUuidandversion(ctx context.Context, 
 		if err := m.Uuidandversion.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("uuidandversion")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("uuidandversion")
 			}
 			return err
 		}

--- a/swagger_models/config_cipher_context.go
+++ b/swagger_models/config_cipher_context.go
@@ -73,6 +73,8 @@ func (m *ConfigCipherContext) validateEncryptionScheme(formats strfmt.Registry) 
 		if err := m.EncryptionScheme.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("encryptionScheme")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("encryptionScheme")
 			}
 			return err
 		}
@@ -90,6 +92,8 @@ func (m *ConfigCipherContext) validateHashScheme(formats strfmt.Registry) error 
 		if err := m.HashScheme.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("hashScheme")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("hashScheme")
 			}
 			return err
 		}
@@ -107,6 +111,8 @@ func (m *ConfigCipherContext) validateKeyExchangeScheme(formats strfmt.Registry)
 		if err := m.KeyExchangeScheme.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keyExchangeScheme")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("keyExchangeScheme")
 			}
 			return err
 		}
@@ -143,6 +149,8 @@ func (m *ConfigCipherContext) contextValidateEncryptionScheme(ctx context.Contex
 		if err := m.EncryptionScheme.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("encryptionScheme")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("encryptionScheme")
 			}
 			return err
 		}
@@ -157,6 +165,8 @@ func (m *ConfigCipherContext) contextValidateHashScheme(ctx context.Context, for
 		if err := m.HashScheme.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("hashScheme")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("hashScheme")
 			}
 			return err
 		}
@@ -171,6 +181,8 @@ func (m *ConfigCipherContext) contextValidateKeyExchangeScheme(ctx context.Conte
 		if err := m.KeyExchangeScheme.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keyExchangeScheme")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("keyExchangeScheme")
 			}
 			return err
 		}

--- a/swagger_models/config_content_tree.go
+++ b/swagger_models/config_content_tree.go
@@ -84,6 +84,8 @@ func (m *ConfigContentTree) validateIformat(formats strfmt.Registry) error {
 		if err := m.Iformat.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("iformat")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("iformat")
 			}
 			return err
 		}
@@ -101,6 +103,8 @@ func (m *ConfigContentTree) validateSiginfo(formats strfmt.Registry) error {
 		if err := m.Siginfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("siginfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("siginfo")
 			}
 			return err
 		}
@@ -133,6 +137,8 @@ func (m *ConfigContentTree) contextValidateIformat(ctx context.Context, formats 
 		if err := m.Iformat.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("iformat")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("iformat")
 			}
 			return err
 		}
@@ -147,6 +153,8 @@ func (m *ConfigContentTree) contextValidateSiginfo(ctx context.Context, formats 
 		if err := m.Siginfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("siginfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("siginfo")
 			}
 			return err
 		}

--- a/swagger_models/config_d_h_c_p_type.go
+++ b/swagger_models/config_d_h_c_p_type.go
@@ -25,8 +25,12 @@ import (
 type ConfigDHCPType string
 
 func NewConfigDHCPType(value ConfigDHCPType) *ConfigDHCPType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigDHCPType.
+func (m ConfigDHCPType) Pointer() *ConfigDHCPType {
+	return &m
 }
 
 const (

--- a/swagger_models/config_datastore_config.go
+++ b/swagger_models/config_datastore_config.go
@@ -77,6 +77,8 @@ func (m *ConfigDatastoreConfig) validateCipherData(formats strfmt.Registry) erro
 		if err := m.CipherData.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cipherData")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cipherData")
 			}
 			return err
 		}
@@ -94,6 +96,8 @@ func (m *ConfigDatastoreConfig) validateDType(formats strfmt.Registry) error {
 		if err := m.DType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dType")
 			}
 			return err
 		}
@@ -126,6 +130,8 @@ func (m *ConfigDatastoreConfig) contextValidateCipherData(ctx context.Context, f
 		if err := m.CipherData.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cipherData")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cipherData")
 			}
 			return err
 		}
@@ -140,6 +146,8 @@ func (m *ConfigDatastoreConfig) contextValidateDType(ctx context.Context, format
 		if err := m.DType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dType")
 			}
 			return err
 		}

--- a/swagger_models/config_drive.go
+++ b/swagger_models/config_drive.go
@@ -73,6 +73,8 @@ func (m *ConfigDrive) validateDrvtype(formats strfmt.Registry) error {
 		if err := m.Drvtype.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("drvtype")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("drvtype")
 			}
 			return err
 		}
@@ -90,6 +92,8 @@ func (m *ConfigDrive) validateImage(formats strfmt.Registry) error {
 		if err := m.Image.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("image")
 			}
 			return err
 		}
@@ -107,6 +111,8 @@ func (m *ConfigDrive) validateTarget(formats strfmt.Registry) error {
 		if err := m.Target.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("target")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("target")
 			}
 			return err
 		}
@@ -143,6 +149,8 @@ func (m *ConfigDrive) contextValidateDrvtype(ctx context.Context, formats strfmt
 		if err := m.Drvtype.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("drvtype")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("drvtype")
 			}
 			return err
 		}
@@ -157,6 +165,8 @@ func (m *ConfigDrive) contextValidateImage(ctx context.Context, formats strfmt.R
 		if err := m.Image.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("image")
 			}
 			return err
 		}
@@ -171,6 +181,8 @@ func (m *ConfigDrive) contextValidateTarget(ctx context.Context, formats strfmt.
 		if err := m.Target.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("target")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("target")
 			}
 			return err
 		}

--- a/swagger_models/config_drive_type.go
+++ b/swagger_models/config_drive_type.go
@@ -25,8 +25,12 @@ import (
 type ConfigDriveType string
 
 func NewConfigDriveType(value ConfigDriveType) *ConfigDriveType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigDriveType.
+func (m ConfigDriveType) Pointer() *ConfigDriveType {
+	return &m
 }
 
 const (

--- a/swagger_models/config_ds_type.go
+++ b/swagger_models/config_ds_type.go
@@ -23,8 +23,12 @@ import (
 type ConfigDsType string
 
 func NewConfigDsType(value ConfigDsType) *ConfigDsType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigDsType.
+func (m ConfigDsType) Pointer() *ConfigDsType {
+	return &m
 }
 
 const (

--- a/swagger_models/config_edge_dev_config.go
+++ b/swagger_models/config_edge_dev_config.go
@@ -216,6 +216,8 @@ func (m *ConfigEdgeDevConfig) validateApps(formats strfmt.Registry) error {
 			if err := m.Apps[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("apps" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("apps" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -235,6 +237,8 @@ func (m *ConfigEdgeDevConfig) validateBackup(formats strfmt.Registry) error {
 		if err := m.Backup.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("backup")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("backup")
 			}
 			return err
 		}
@@ -257,6 +261,8 @@ func (m *ConfigEdgeDevConfig) validateBase(formats strfmt.Registry) error {
 			if err := m.Base[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("base" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("base" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -276,6 +282,8 @@ func (m *ConfigEdgeDevConfig) validateBaseos(formats strfmt.Registry) error {
 		if err := m.Baseos.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("baseos")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("baseos")
 			}
 			return err
 		}
@@ -298,6 +306,8 @@ func (m *ConfigEdgeDevConfig) validateCipherContexts(formats strfmt.Registry) er
 			if err := m.CipherContexts[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("cipherContexts" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cipherContexts" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -322,6 +332,8 @@ func (m *ConfigEdgeDevConfig) validateConfigItems(formats strfmt.Registry) error
 			if err := m.ConfigItems[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("configItems" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("configItems" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -346,6 +358,8 @@ func (m *ConfigEdgeDevConfig) validateContentInfo(formats strfmt.Registry) error
 			if err := m.ContentInfo[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("contentInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("contentInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -370,6 +384,8 @@ func (m *ConfigEdgeDevConfig) validateDatastores(formats strfmt.Registry) error 
 			if err := m.Datastores[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("datastores" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("datastores" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -394,6 +410,8 @@ func (m *ConfigEdgeDevConfig) validateDeviceIoList(formats strfmt.Registry) erro
 			if err := m.DeviceIoList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("deviceIoList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("deviceIoList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -413,6 +431,8 @@ func (m *ConfigEdgeDevConfig) validateID(formats strfmt.Registry) error {
 		if err := m.ID.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("id")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("id")
 			}
 			return err
 		}
@@ -435,6 +455,8 @@ func (m *ConfigEdgeDevConfig) validateNetworkInstances(formats strfmt.Registry) 
 			if err := m.NetworkInstances[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("networkInstances" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("networkInstances" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -459,6 +481,8 @@ func (m *ConfigEdgeDevConfig) validateNetworks(formats strfmt.Registry) error {
 			if err := m.Networks[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("networks" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("networks" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -478,6 +502,8 @@ func (m *ConfigEdgeDevConfig) validateReboot(formats strfmt.Registry) error {
 		if err := m.Reboot.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("reboot")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("reboot")
 			}
 			return err
 		}
@@ -500,6 +526,8 @@ func (m *ConfigEdgeDevConfig) validateSystemAdapterList(formats strfmt.Registry)
 			if err := m.SystemAdapterList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("systemAdapterList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("systemAdapterList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -524,6 +552,8 @@ func (m *ConfigEdgeDevConfig) validateVolumes(formats strfmt.Registry) error {
 			if err := m.Volumes[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("volumes" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("volumes" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -612,6 +642,8 @@ func (m *ConfigEdgeDevConfig) contextValidateApps(ctx context.Context, formats s
 			if err := m.Apps[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("apps" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("apps" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -628,6 +660,8 @@ func (m *ConfigEdgeDevConfig) contextValidateBackup(ctx context.Context, formats
 		if err := m.Backup.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("backup")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("backup")
 			}
 			return err
 		}
@@ -644,6 +678,8 @@ func (m *ConfigEdgeDevConfig) contextValidateBase(ctx context.Context, formats s
 			if err := m.Base[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("base" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("base" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -660,6 +696,8 @@ func (m *ConfigEdgeDevConfig) contextValidateBaseos(ctx context.Context, formats
 		if err := m.Baseos.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("baseos")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("baseos")
 			}
 			return err
 		}
@@ -676,6 +714,8 @@ func (m *ConfigEdgeDevConfig) contextValidateCipherContexts(ctx context.Context,
 			if err := m.CipherContexts[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("cipherContexts" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cipherContexts" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -694,6 +734,8 @@ func (m *ConfigEdgeDevConfig) contextValidateConfigItems(ctx context.Context, fo
 			if err := m.ConfigItems[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("configItems" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("configItems" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -712,6 +754,8 @@ func (m *ConfigEdgeDevConfig) contextValidateContentInfo(ctx context.Context, fo
 			if err := m.ContentInfo[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("contentInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("contentInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -730,6 +774,8 @@ func (m *ConfigEdgeDevConfig) contextValidateDatastores(ctx context.Context, for
 			if err := m.Datastores[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("datastores" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("datastores" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -748,6 +794,8 @@ func (m *ConfigEdgeDevConfig) contextValidateDeviceIoList(ctx context.Context, f
 			if err := m.DeviceIoList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("deviceIoList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("deviceIoList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -764,6 +812,8 @@ func (m *ConfigEdgeDevConfig) contextValidateID(ctx context.Context, formats str
 		if err := m.ID.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("id")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("id")
 			}
 			return err
 		}
@@ -780,6 +830,8 @@ func (m *ConfigEdgeDevConfig) contextValidateNetworkInstances(ctx context.Contex
 			if err := m.NetworkInstances[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("networkInstances" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("networkInstances" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -798,6 +850,8 @@ func (m *ConfigEdgeDevConfig) contextValidateNetworks(ctx context.Context, forma
 			if err := m.Networks[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("networks" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("networks" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -814,6 +868,8 @@ func (m *ConfigEdgeDevConfig) contextValidateReboot(ctx context.Context, formats
 		if err := m.Reboot.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("reboot")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("reboot")
 			}
 			return err
 		}
@@ -830,6 +886,8 @@ func (m *ConfigEdgeDevConfig) contextValidateSystemAdapterList(ctx context.Conte
 			if err := m.SystemAdapterList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("systemAdapterList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("systemAdapterList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -848,6 +906,8 @@ func (m *ConfigEdgeDevConfig) contextValidateVolumes(ctx context.Context, format
 			if err := m.Volumes[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("volumes" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("volumes" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/config_encryption_scheme.go
+++ b/swagger_models/config_encryption_scheme.go
@@ -23,8 +23,12 @@ import (
 type ConfigEncryptionScheme string
 
 func NewConfigEncryptionScheme(value ConfigEncryptionScheme) *ConfigEncryptionScheme {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigEncryptionScheme.
+func (m ConfigEncryptionScheme) Pointer() *ConfigEncryptionScheme {
+	return &m
 }
 
 const (

--- a/swagger_models/config_format.go
+++ b/swagger_models/config_format.go
@@ -23,8 +23,12 @@ import (
 type ConfigFormat string
 
 func NewConfigFormat(value ConfigFormat) *ConfigFormat {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigFormat.
+func (m ConfigFormat) Pointer() *ConfigFormat {
+	return &m
 }
 
 const (

--- a/swagger_models/config_key_exchange_scheme.go
+++ b/swagger_models/config_key_exchange_scheme.go
@@ -23,8 +23,12 @@ import (
 type ConfigKeyExchangeScheme string
 
 func NewConfigKeyExchangeScheme(value ConfigKeyExchangeScheme) *ConfigKeyExchangeScheme {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigKeyExchangeScheme.
+func (m ConfigKeyExchangeScheme) Pointer() *ConfigKeyExchangeScheme {
+	return &m
 }
 
 const (

--- a/swagger_models/config_meta_data_type.go
+++ b/swagger_models/config_meta_data_type.go
@@ -23,8 +23,12 @@ import (
 type ConfigMetaDataType string
 
 func NewConfigMetaDataType(value ConfigMetaDataType) *ConfigMetaDataType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigMetaDataType.
+func (m ConfigMetaDataType) Pointer() *ConfigMetaDataType {
+	return &m
 }
 
 const (

--- a/swagger_models/config_network_adapter.go
+++ b/swagger_models/config_network_adapter.go
@@ -90,6 +90,8 @@ func (m *ConfigNetworkAdapter) validateAcls(formats strfmt.Registry) error {
 			if err := m.Acls[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("acls" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("acls" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -122,6 +124,8 @@ func (m *ConfigNetworkAdapter) contextValidateAcls(ctx context.Context, formats 
 			if err := m.Acls[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("acls" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("acls" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/config_network_config.go
+++ b/swagger_models/config_network_config.go
@@ -85,6 +85,8 @@ func (m *ConfigNetworkConfig) validateDNS(formats strfmt.Registry) error {
 			if err := m.DNS[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("dns" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("dns" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -104,6 +106,8 @@ func (m *ConfigNetworkConfig) validateEntProxy(formats strfmt.Registry) error {
 		if err := m.EntProxy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("entProxy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("entProxy")
 			}
 			return err
 		}
@@ -121,6 +125,8 @@ func (m *ConfigNetworkConfig) validateIP(formats strfmt.Registry) error {
 		if err := m.IP.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ip")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ip")
 			}
 			return err
 		}
@@ -138,6 +144,8 @@ func (m *ConfigNetworkConfig) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -155,6 +163,8 @@ func (m *ConfigNetworkConfig) validateWireless(formats strfmt.Registry) error {
 		if err := m.Wireless.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("wireless")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("wireless")
 			}
 			return err
 		}
@@ -201,6 +211,8 @@ func (m *ConfigNetworkConfig) contextValidateDNS(ctx context.Context, formats st
 			if err := m.DNS[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("dns" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("dns" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -217,6 +229,8 @@ func (m *ConfigNetworkConfig) contextValidateEntProxy(ctx context.Context, forma
 		if err := m.EntProxy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("entProxy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("entProxy")
 			}
 			return err
 		}
@@ -231,6 +245,8 @@ func (m *ConfigNetworkConfig) contextValidateIP(ctx context.Context, formats str
 		if err := m.IP.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ip")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ip")
 			}
 			return err
 		}
@@ -245,6 +261,8 @@ func (m *ConfigNetworkConfig) contextValidateType(ctx context.Context, formats s
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -259,6 +277,8 @@ func (m *ConfigNetworkConfig) contextValidateWireless(ctx context.Context, forma
 		if err := m.Wireless.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("wireless")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("wireless")
 			}
 			return err
 		}

--- a/swagger_models/config_network_instance_config.go
+++ b/swagger_models/config_network_instance_config.go
@@ -106,6 +106,8 @@ func (m *ConfigNetworkInstanceConfig) validateCfg(formats strfmt.Registry) error
 		if err := m.Cfg.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cfg")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cfg")
 			}
 			return err
 		}
@@ -128,6 +130,8 @@ func (m *ConfigNetworkInstanceConfig) validateDNS(formats strfmt.Registry) error
 			if err := m.DNS[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("dns" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("dns" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -147,6 +151,8 @@ func (m *ConfigNetworkInstanceConfig) validateInstType(formats strfmt.Registry) 
 		if err := m.InstType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("instType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("instType")
 			}
 			return err
 		}
@@ -164,6 +170,8 @@ func (m *ConfigNetworkInstanceConfig) validateIP(formats strfmt.Registry) error 
 		if err := m.IP.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ip")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ip")
 			}
 			return err
 		}
@@ -181,6 +189,8 @@ func (m *ConfigNetworkInstanceConfig) validateIPType(formats strfmt.Registry) er
 		if err := m.IPType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ipType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ipType")
 			}
 			return err
 		}
@@ -198,6 +208,8 @@ func (m *ConfigNetworkInstanceConfig) validatePort(formats strfmt.Registry) erro
 		if err := m.Port.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("port")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("port")
 			}
 			return err
 		}
@@ -215,6 +227,8 @@ func (m *ConfigNetworkInstanceConfig) validateUuidandversion(formats strfmt.Regi
 		if err := m.Uuidandversion.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("uuidandversion")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("uuidandversion")
 			}
 			return err
 		}
@@ -267,6 +281,8 @@ func (m *ConfigNetworkInstanceConfig) contextValidateCfg(ctx context.Context, fo
 		if err := m.Cfg.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cfg")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cfg")
 			}
 			return err
 		}
@@ -283,6 +299,8 @@ func (m *ConfigNetworkInstanceConfig) contextValidateDNS(ctx context.Context, fo
 			if err := m.DNS[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("dns" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("dns" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -299,6 +317,8 @@ func (m *ConfigNetworkInstanceConfig) contextValidateInstType(ctx context.Contex
 		if err := m.InstType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("instType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("instType")
 			}
 			return err
 		}
@@ -313,6 +333,8 @@ func (m *ConfigNetworkInstanceConfig) contextValidateIP(ctx context.Context, for
 		if err := m.IP.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ip")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ip")
 			}
 			return err
 		}
@@ -327,6 +349,8 @@ func (m *ConfigNetworkInstanceConfig) contextValidateIPType(ctx context.Context,
 		if err := m.IPType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ipType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ipType")
 			}
 			return err
 		}
@@ -341,6 +365,8 @@ func (m *ConfigNetworkInstanceConfig) contextValidatePort(ctx context.Context, f
 		if err := m.Port.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("port")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("port")
 			}
 			return err
 		}
@@ -355,6 +381,8 @@ func (m *ConfigNetworkInstanceConfig) contextValidateUuidandversion(ctx context.
 		if err := m.Uuidandversion.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("uuidandversion")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("uuidandversion")
 			}
 			return err
 		}

--- a/swagger_models/config_network_instance_lisp_config.go
+++ b/swagger_models/config_network_instance_lisp_config.go
@@ -73,6 +73,8 @@ func (m *ConfigNetworkInstanceLispConfig) validateLispMSs(formats strfmt.Registr
 			if err := m.LispMSs[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("LispMSs" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("LispMSs" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -105,6 +107,8 @@ func (m *ConfigNetworkInstanceLispConfig) contextValidateLispMSs(ctx context.Con
 			if err := m.LispMSs[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("LispMSs" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("LispMSs" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/config_network_instance_opaque_config.go
+++ b/swagger_models/config_network_instance_opaque_config.go
@@ -59,6 +59,8 @@ func (m *ConfigNetworkInstanceOpaqueConfig) validateLispConfig(formats strfmt.Re
 		if err := m.LispConfig.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("lispConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("lispConfig")
 			}
 			return err
 		}
@@ -76,6 +78,8 @@ func (m *ConfigNetworkInstanceOpaqueConfig) validateType(formats strfmt.Registry
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -108,6 +112,8 @@ func (m *ConfigNetworkInstanceOpaqueConfig) contextValidateLispConfig(ctx contex
 		if err := m.LispConfig.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("lispConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("lispConfig")
 			}
 			return err
 		}
@@ -122,6 +128,8 @@ func (m *ConfigNetworkInstanceOpaqueConfig) contextValidateType(ctx context.Cont
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/config_network_type.go
+++ b/swagger_models/config_network_type.go
@@ -23,8 +23,12 @@ import (
 type ConfigNetworkType string
 
 func NewConfigNetworkType(value ConfigNetworkType) *ConfigNetworkType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigNetworkType.
+func (m ConfigNetworkType) Pointer() *ConfigNetworkType {
+	return &m
 }
 
 const (

--- a/swagger_models/config_physical_i_o.go
+++ b/swagger_models/config_physical_i_o.go
@@ -114,6 +114,8 @@ func (m *ConfigPhysicalIO) validatePtype(formats strfmt.Registry) error {
 		if err := m.Ptype.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ptype")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ptype")
 			}
 			return err
 		}
@@ -131,6 +133,8 @@ func (m *ConfigPhysicalIO) validateUsage(formats strfmt.Registry) error {
 		if err := m.Usage.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("usage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("usage")
 			}
 			return err
 		}
@@ -148,6 +152,8 @@ func (m *ConfigPhysicalIO) validateUsagePolicy(formats strfmt.Registry) error {
 		if err := m.UsagePolicy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("usagePolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("usagePolicy")
 			}
 			return err
 		}
@@ -184,6 +190,8 @@ func (m *ConfigPhysicalIO) contextValidatePtype(ctx context.Context, formats str
 		if err := m.Ptype.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ptype")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ptype")
 			}
 			return err
 		}
@@ -198,6 +206,8 @@ func (m *ConfigPhysicalIO) contextValidateUsage(ctx context.Context, formats str
 		if err := m.Usage.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("usage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("usage")
 			}
 			return err
 		}
@@ -212,6 +222,8 @@ func (m *ConfigPhysicalIO) contextValidateUsagePolicy(ctx context.Context, forma
 		if err := m.UsagePolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("usagePolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("usagePolicy")
 			}
 			return err
 		}

--- a/swagger_models/config_proxy_config.go
+++ b/swagger_models/config_proxy_config.go
@@ -72,6 +72,8 @@ func (m *ConfigProxyConfig) validateProxies(formats strfmt.Registry) error {
 			if err := m.Proxies[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("proxies" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("proxies" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -104,6 +106,8 @@ func (m *ConfigProxyConfig) contextValidateProxies(ctx context.Context, formats 
 			if err := m.Proxies[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("proxies" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("proxies" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/config_proxy_server.go
+++ b/swagger_models/config_proxy_server.go
@@ -54,6 +54,8 @@ func (m *ConfigProxyServer) validateProto(formats strfmt.Registry) error {
 		if err := m.Proto.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("proto")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("proto")
 			}
 			return err
 		}
@@ -82,6 +84,8 @@ func (m *ConfigProxyServer) contextValidateProto(ctx context.Context, formats st
 		if err := m.Proto.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("proto")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("proto")
 			}
 			return err
 		}

--- a/swagger_models/config_service_resp.go
+++ b/swagger_models/config_service_resp.go
@@ -90,6 +90,8 @@ func (m *ConfigServiceResp) validateConfig(formats strfmt.Registry) error {
 		if err := m.Config.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("config")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("config")
 			}
 			return err
 		}
@@ -119,6 +121,8 @@ func (m *ConfigServiceResp) validateLastKnownStatus(formats strfmt.Registry) err
 		if err := m.LastKnownStatus.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("lastKnownStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("lastKnownStatus")
 			}
 			return err
 		}
@@ -148,6 +152,8 @@ func (m *ConfigServiceResp) validateResult(formats strfmt.Registry) error {
 		if err := m.Result.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("result")
 			}
 			return err
 		}
@@ -196,6 +202,8 @@ func (m *ConfigServiceResp) contextValidateConfig(ctx context.Context, formats s
 		if err := m.Config.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("config")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("config")
 			}
 			return err
 		}
@@ -210,6 +218,8 @@ func (m *ConfigServiceResp) contextValidateLastKnownStatus(ctx context.Context, 
 		if err := m.LastKnownStatus.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("lastKnownStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("lastKnownStatus")
 			}
 			return err
 		}
@@ -224,6 +234,8 @@ func (m *ConfigServiceResp) contextValidateResult(ctx context.Context, formats s
 		if err := m.Result.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("result")
 			}
 			return err
 		}

--- a/swagger_models/config_target.go
+++ b/swagger_models/config_target.go
@@ -23,8 +23,12 @@ import (
 type ConfigTarget string
 
 func NewConfigTarget(value ConfigTarget) *ConfigTarget {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigTarget.
+func (m ConfigTarget) Pointer() *ConfigTarget {
+	return &m
 }
 
 const (

--- a/swagger_models/config_vm_config.go
+++ b/swagger_models/config_vm_config.go
@@ -99,6 +99,8 @@ func (m *ConfigVMConfig) validateVirtualizationMode(formats strfmt.Registry) err
 		if err := m.VirtualizationMode.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("virtualizationMode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("virtualizationMode")
 			}
 			return err
 		}
@@ -127,6 +129,8 @@ func (m *ConfigVMConfig) contextValidateVirtualizationMode(ctx context.Context, 
 		if err := m.VirtualizationMode.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("virtualizationMode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("virtualizationMode")
 			}
 			return err
 		}

--- a/swagger_models/config_vm_mode.go
+++ b/swagger_models/config_vm_mode.go
@@ -26,8 +26,12 @@ import (
 type ConfigVMMode string
 
 func NewConfigVMMode(value ConfigVMMode) *ConfigVMMode {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigVMMode.
+func (m ConfigVMMode) Pointer() *ConfigVMMode {
+	return &m
 }
 
 const (

--- a/swagger_models/config_volume.go
+++ b/swagger_models/config_volume.go
@@ -83,6 +83,8 @@ func (m *ConfigVolume) validateOrigin(formats strfmt.Registry) error {
 		if err := m.Origin.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("origin")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("origin")
 			}
 			return err
 		}
@@ -105,6 +107,8 @@ func (m *ConfigVolume) validateProtocols(formats strfmt.Registry) error {
 			if err := m.Protocols[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("protocols" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("protocols" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -139,6 +143,8 @@ func (m *ConfigVolume) contextValidateOrigin(ctx context.Context, formats strfmt
 		if err := m.Origin.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("origin")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("origin")
 			}
 			return err
 		}
@@ -155,6 +161,8 @@ func (m *ConfigVolume) contextValidateProtocols(ctx context.Context, formats str
 			if err := m.Protocols[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("protocols" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("protocols" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/config_volume_access_protocols.go
+++ b/swagger_models/config_volume_access_protocols.go
@@ -23,8 +23,12 @@ import (
 type ConfigVolumeAccessProtocols string
 
 func NewConfigVolumeAccessProtocols(value ConfigVolumeAccessProtocols) *ConfigVolumeAccessProtocols {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigVolumeAccessProtocols.
+func (m ConfigVolumeAccessProtocols) Pointer() *ConfigVolumeAccessProtocols {
+	return &m
 }
 
 const (

--- a/swagger_models/config_volume_content_origin.go
+++ b/swagger_models/config_volume_content_origin.go
@@ -51,6 +51,8 @@ func (m *ConfigVolumeContentOrigin) validateType(formats strfmt.Registry) error 
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -79,6 +81,8 @@ func (m *ConfigVolumeContentOrigin) contextValidateType(ctx context.Context, for
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/config_volume_content_origin_type.go
+++ b/swagger_models/config_volume_content_origin_type.go
@@ -23,8 +23,12 @@ import (
 type ConfigVolumeContentOriginType string
 
 func NewConfigVolumeContentOriginType(value ConfigVolumeContentOriginType) *ConfigVolumeContentOriginType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigVolumeContentOriginType.
+func (m ConfigVolumeContentOriginType) Pointer() *ConfigVolumeContentOriginType {
+	return &m
 }
 
 const (

--- a/swagger_models/config_wi_fi_key_scheme.go
+++ b/swagger_models/config_wi_fi_key_scheme.go
@@ -23,8 +23,12 @@ import (
 type ConfigWiFiKeyScheme string
 
 func NewConfigWiFiKeyScheme(value ConfigWiFiKeyScheme) *ConfigWiFiKeyScheme {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigWiFiKeyScheme.
+func (m ConfigWiFiKeyScheme) Pointer() *ConfigWiFiKeyScheme {
+	return &m
 }
 
 const (

--- a/swagger_models/config_wifi_config.go
+++ b/swagger_models/config_wifi_config.go
@@ -74,6 +74,8 @@ func (m *ConfigWifiConfig) validateCipherData(formats strfmt.Registry) error {
 		if err := m.CipherData.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cipherData")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cipherData")
 			}
 			return err
 		}
@@ -91,6 +93,8 @@ func (m *ConfigWifiConfig) validateCrypto(formats strfmt.Registry) error {
 		if err := m.Crypto.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("crypto")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("crypto")
 			}
 			return err
 		}
@@ -108,6 +112,8 @@ func (m *ConfigWifiConfig) validateKeyScheme(formats strfmt.Registry) error {
 		if err := m.KeyScheme.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keyScheme")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("keyScheme")
 			}
 			return err
 		}
@@ -144,6 +150,8 @@ func (m *ConfigWifiConfig) contextValidateCipherData(ctx context.Context, format
 		if err := m.CipherData.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cipherData")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cipherData")
 			}
 			return err
 		}
@@ -158,6 +166,8 @@ func (m *ConfigWifiConfig) contextValidateCrypto(ctx context.Context, formats st
 		if err := m.Crypto.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("crypto")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("crypto")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *ConfigWifiConfig) contextValidateKeyScheme(ctx context.Context, formats
 		if err := m.KeyScheme.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keyScheme")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("keyScheme")
 			}
 			return err
 		}

--- a/swagger_models/config_wireless_config.go
+++ b/swagger_models/config_wireless_config.go
@@ -68,6 +68,8 @@ func (m *ConfigWirelessConfig) validateCellularCfg(formats strfmt.Registry) erro
 			if err := m.CellularCfg[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("cellularCfg" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cellularCfg" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *ConfigWirelessConfig) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -109,6 +113,8 @@ func (m *ConfigWirelessConfig) validateWifiCfg(formats strfmt.Registry) error {
 			if err := m.WifiCfg[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("wifiCfg" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("wifiCfg" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -149,6 +155,8 @@ func (m *ConfigWirelessConfig) contextValidateCellularCfg(ctx context.Context, f
 			if err := m.CellularCfg[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("cellularCfg" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cellularCfg" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -165,6 +173,8 @@ func (m *ConfigWirelessConfig) contextValidateType(ctx context.Context, formats 
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -181,6 +191,8 @@ func (m *ConfigWirelessConfig) contextValidateWifiCfg(ctx context.Context, forma
 			if err := m.WifiCfg[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("wifiCfg" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("wifiCfg" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/config_wireless_type.go
+++ b/swagger_models/config_wireless_type.go
@@ -23,8 +23,12 @@ import (
 type ConfigWirelessType string
 
 func NewConfigWirelessType(value ConfigWirelessType) *ConfigWirelessType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigWirelessType.
+func (m ConfigWirelessType) Pointer() *ConfigWirelessType {
+	return &m
 }
 
 const (

--- a/swagger_models/config_z_network_inst_type.go
+++ b/swagger_models/config_z_network_inst_type.go
@@ -23,8 +23,12 @@ import (
 type ConfigZNetworkInstType string
 
 func NewConfigZNetworkInstType(value ConfigZNetworkInstType) *ConfigZNetworkInstType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigZNetworkInstType.
+func (m ConfigZNetworkInstType) Pointer() *ConfigZNetworkInstType {
+	return &m
 }
 
 const (

--- a/swagger_models/config_z_network_opaque_config_type.go
+++ b/swagger_models/config_z_network_opaque_config_type.go
@@ -23,8 +23,12 @@ import (
 type ConfigZNetworkOpaqueConfigType string
 
 func NewConfigZNetworkOpaqueConfigType(value ConfigZNetworkOpaqueConfigType) *ConfigZNetworkOpaqueConfigType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigZNetworkOpaqueConfigType.
+func (m ConfigZNetworkOpaqueConfigType) Pointer() *ConfigZNetworkOpaqueConfigType {
+	return &m
 }
 
 const (

--- a/swagger_models/config_zc_service_point.go
+++ b/swagger_models/config_zc_service_point.go
@@ -55,6 +55,8 @@ func (m *ConfigZcServicePoint) validateZsType(formats strfmt.Registry) error {
 		if err := m.ZsType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("zsType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("zsType")
 			}
 			return err
 		}
@@ -83,6 +85,8 @@ func (m *ConfigZcServicePoint) contextValidateZsType(ctx context.Context, format
 		if err := m.ZsType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("zsType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("zsType")
 			}
 			return err
 		}

--- a/swagger_models/config_zc_service_type.go
+++ b/swagger_models/config_zc_service_type.go
@@ -25,8 +25,12 @@ import (
 type ConfigZcServiceType string
 
 func NewConfigZcServiceType(value ConfigZcServiceType) *ConfigZcServiceType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigZcServiceType.
+func (m ConfigZcServiceType) Pointer() *ConfigZcServiceType {
+	return &m
 }
 
 const (

--- a/swagger_models/configipspec.go
+++ b/swagger_models/configipspec.go
@@ -71,6 +71,8 @@ func (m *Configipspec) validateDhcp(formats strfmt.Registry) error {
 		if err := m.Dhcp.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dhcp")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dhcp")
 			}
 			return err
 		}
@@ -88,6 +90,8 @@ func (m *Configipspec) validateDhcpRange(formats strfmt.Registry) error {
 		if err := m.DhcpRange.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dhcpRange")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dhcpRange")
 			}
 			return err
 		}
@@ -120,6 +124,8 @@ func (m *Configipspec) contextValidateDhcp(ctx context.Context, formats strfmt.R
 		if err := m.Dhcp.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dhcp")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dhcp")
 			}
 			return err
 		}
@@ -134,6 +140,8 @@ func (m *Configipspec) contextValidateDhcpRange(ctx context.Context, formats str
 		if err := m.DhcpRange.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dhcpRange")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dhcpRange")
 			}
 			return err
 		}

--- a/swagger_models/configproxy_proto.go
+++ b/swagger_models/configproxy_proto.go
@@ -23,8 +23,12 @@ import (
 type ConfigproxyProto string
 
 func NewConfigproxyProto(value ConfigproxyProto) *ConfigproxyProto {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ConfigproxyProto.
+func (m ConfigproxyProto) Pointer() *ConfigproxyProto {
+	return &m
 }
 
 const (

--- a/swagger_models/controller_type.go
+++ b/swagger_models/controller_type.go
@@ -23,8 +23,12 @@ import (
 type ControllerType string
 
 func NewControllerType(value ControllerType) *ControllerType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ControllerType.
+func (m ControllerType) Pointer() *ControllerType {
+	return &m
 }
 
 const (

--- a/swagger_models/credential.go
+++ b/swagger_models/credential.go
@@ -66,6 +66,8 @@ func (m *Credential) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -94,6 +96,8 @@ func (m *Credential) contextValidateType(ctx context.Context, formats strfmt.Reg
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/credential_type.go
+++ b/swagger_models/credential_type.go
@@ -23,8 +23,12 @@ import (
 type CredentialType string
 
 func NewCredentialType(value CredentialType) *CredentialType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated CredentialType.
+func (m CredentialType) Pointer() *CredentialType {
+	return &m
 }
 
 const (

--- a/swagger_models/credentials.go
+++ b/swagger_models/credentials.go
@@ -68,6 +68,8 @@ func (m *Credentials) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *Credentials) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *Credentials) validateSummaryByState(formats strfmt.Registry) error {
 		if err := m.SummaryByState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *Credentials) contextValidateList(ctx context.Context, formats strfmt.Re
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -158,6 +166,8 @@ func (m *Credentials) contextValidateNext(ctx context.Context, formats strfmt.Re
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *Credentials) contextValidateSummaryByState(ctx context.Context, formats
 		if err := m.SummaryByState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}

--- a/swagger_models/crud_action.go
+++ b/swagger_models/crud_action.go
@@ -23,8 +23,12 @@ import (
 type CrudAction string
 
 func NewCrudAction(value CrudAction) *CrudAction {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated CrudAction.
+func (m CrudAction) Pointer() *CrudAction {
+	return &m
 }
 
 const (

--- a/swagger_models/crud_content.go
+++ b/swagger_models/crud_content.go
@@ -76,6 +76,8 @@ func (m *CrudContent) validateClazz(formats strfmt.Registry) error {
 		if err := m.Clazz.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("clazz")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("clazz")
 			}
 			return err
 		}
@@ -93,6 +95,8 @@ func (m *CrudContent) validateEncoding(formats strfmt.Registry) error {
 		if err := m.Encoding.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("encoding")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("encoding")
 			}
 			return err
 		}
@@ -110,6 +114,8 @@ func (m *CrudContent) validateJSON(formats strfmt.Registry) error {
 		if err := m.JSON.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("json")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("json")
 			}
 			return err
 		}
@@ -127,6 +133,8 @@ func (m *CrudContent) validateOid(formats strfmt.Registry) error {
 		if err := m.Oid.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("oid")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("oid")
 			}
 			return err
 		}
@@ -144,6 +152,8 @@ func (m *CrudContent) validateProtobuf(formats strfmt.Registry) error {
 		if err := m.Protobuf.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("protobuf")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("protobuf")
 			}
 			return err
 		}
@@ -188,6 +198,8 @@ func (m *CrudContent) contextValidateClazz(ctx context.Context, formats strfmt.R
 		if err := m.Clazz.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("clazz")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("clazz")
 			}
 			return err
 		}
@@ -202,6 +214,8 @@ func (m *CrudContent) contextValidateEncoding(ctx context.Context, formats strfm
 		if err := m.Encoding.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("encoding")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("encoding")
 			}
 			return err
 		}
@@ -216,6 +230,8 @@ func (m *CrudContent) contextValidateJSON(ctx context.Context, formats strfmt.Re
 		if err := m.JSON.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("json")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("json")
 			}
 			return err
 		}
@@ -230,6 +246,8 @@ func (m *CrudContent) contextValidateOid(ctx context.Context, formats strfmt.Reg
 		if err := m.Oid.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("oid")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("oid")
 			}
 			return err
 		}
@@ -244,6 +262,8 @@ func (m *CrudContent) contextValidateProtobuf(ctx context.Context, formats strfm
 		if err := m.Protobuf.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("protobuf")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("protobuf")
 			}
 			return err
 		}

--- a/swagger_models/crud_content_encoding.go
+++ b/swagger_models/crud_content_encoding.go
@@ -23,8 +23,12 @@ import (
 type CrudContentEncoding string
 
 func NewCrudContentEncoding(value CrudContentEncoding) *CrudContentEncoding {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated CrudContentEncoding.
+func (m CrudContentEncoding) Pointer() *CrudContentEncoding {
+	return &m
 }
 
 const (

--- a/swagger_models/crud_content_protobuf.go
+++ b/swagger_models/crud_content_protobuf.go
@@ -117,6 +117,8 @@ func (m *CrudContentProtobuf) validateCredential(formats strfmt.Registry) error 
 		if err := m.Credential.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("credential")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("credential")
 			}
 			return err
 		}
@@ -134,6 +136,8 @@ func (m *CrudContentProtobuf) validateDetailedUser(formats strfmt.Registry) erro
 		if err := m.DetailedUser.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("detailedUser")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("detailedUser")
 			}
 			return err
 		}
@@ -151,6 +155,8 @@ func (m *CrudContentProtobuf) validateDocPolicy(formats strfmt.Registry) error {
 		if err := m.DocPolicy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("docPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("docPolicy")
 			}
 			return err
 		}
@@ -168,6 +174,8 @@ func (m *CrudContentProtobuf) validateEnterprise(formats strfmt.Registry) error 
 		if err := m.Enterprise.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("enterprise")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("enterprise")
 			}
 			return err
 		}
@@ -185,6 +193,8 @@ func (m *CrudContentProtobuf) validatePolicy(formats strfmt.Registry) error {
 		if err := m.Policy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("policy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("policy")
 			}
 			return err
 		}
@@ -202,6 +212,8 @@ func (m *CrudContentProtobuf) validateProfile(formats strfmt.Registry) error {
 		if err := m.Profile.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("profile")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("profile")
 			}
 			return err
 		}
@@ -219,6 +231,8 @@ func (m *CrudContentProtobuf) validateRealm(formats strfmt.Registry) error {
 		if err := m.Realm.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realm")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("realm")
 			}
 			return err
 		}
@@ -236,6 +250,8 @@ func (m *CrudContentProtobuf) validateRole(formats strfmt.Registry) error {
 		if err := m.Role.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("role")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("role")
 			}
 			return err
 		}
@@ -253,6 +269,8 @@ func (m *CrudContentProtobuf) validateSimpleUser(formats strfmt.Registry) error 
 		if err := m.SimpleUser.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("simpleUser")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("simpleUser")
 			}
 			return err
 		}
@@ -270,6 +288,8 @@ func (m *CrudContentProtobuf) validateUser(formats strfmt.Registry) error {
 		if err := m.User.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("user")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("user")
 			}
 			return err
 		}
@@ -334,6 +354,8 @@ func (m *CrudContentProtobuf) contextValidateCredential(ctx context.Context, for
 		if err := m.Credential.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("credential")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("credential")
 			}
 			return err
 		}
@@ -348,6 +370,8 @@ func (m *CrudContentProtobuf) contextValidateDetailedUser(ctx context.Context, f
 		if err := m.DetailedUser.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("detailedUser")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("detailedUser")
 			}
 			return err
 		}
@@ -362,6 +386,8 @@ func (m *CrudContentProtobuf) contextValidateDocPolicy(ctx context.Context, form
 		if err := m.DocPolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("docPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("docPolicy")
 			}
 			return err
 		}
@@ -376,6 +402,8 @@ func (m *CrudContentProtobuf) contextValidateEnterprise(ctx context.Context, for
 		if err := m.Enterprise.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("enterprise")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("enterprise")
 			}
 			return err
 		}
@@ -390,6 +418,8 @@ func (m *CrudContentProtobuf) contextValidatePolicy(ctx context.Context, formats
 		if err := m.Policy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("policy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("policy")
 			}
 			return err
 		}
@@ -404,6 +434,8 @@ func (m *CrudContentProtobuf) contextValidateProfile(ctx context.Context, format
 		if err := m.Profile.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("profile")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("profile")
 			}
 			return err
 		}
@@ -418,6 +450,8 @@ func (m *CrudContentProtobuf) contextValidateRealm(ctx context.Context, formats 
 		if err := m.Realm.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realm")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("realm")
 			}
 			return err
 		}
@@ -432,6 +466,8 @@ func (m *CrudContentProtobuf) contextValidateRole(ctx context.Context, formats s
 		if err := m.Role.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("role")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("role")
 			}
 			return err
 		}
@@ -446,6 +482,8 @@ func (m *CrudContentProtobuf) contextValidateSimpleUser(ctx context.Context, for
 		if err := m.SimpleUser.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("simpleUser")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("simpleUser")
 			}
 			return err
 		}
@@ -460,6 +498,8 @@ func (m *CrudContentProtobuf) contextValidateUser(ctx context.Context, formats s
 		if err := m.User.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("user")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("user")
 			}
 			return err
 		}

--- a/swagger_models/crud_response.go
+++ b/swagger_models/crud_response.go
@@ -76,6 +76,8 @@ func (m *CrudResponse) validateAction(formats strfmt.Registry) error {
 		if err := m.Action.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("action")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("action")
 			}
 			return err
 		}
@@ -93,6 +95,8 @@ func (m *CrudResponse) validateQuery(formats strfmt.Registry) error {
 		if err := m.Query.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("query")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("query")
 			}
 			return err
 		}
@@ -110,6 +114,8 @@ func (m *CrudResponse) validateRead(formats strfmt.Registry) error {
 		if err := m.Read.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("read")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("read")
 			}
 			return err
 		}
@@ -127,6 +133,8 @@ func (m *CrudResponse) validateResult(formats strfmt.Registry) error {
 		if err := m.Result.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("result")
 			}
 			return err
 		}
@@ -144,6 +152,8 @@ func (m *CrudResponse) validateToken(formats strfmt.Registry) error {
 		if err := m.Token.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("token")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("token")
 			}
 			return err
 		}
@@ -188,6 +198,8 @@ func (m *CrudResponse) contextValidateAction(ctx context.Context, formats strfmt
 		if err := m.Action.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("action")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("action")
 			}
 			return err
 		}
@@ -202,6 +214,8 @@ func (m *CrudResponse) contextValidateQuery(ctx context.Context, formats strfmt.
 		if err := m.Query.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("query")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("query")
 			}
 			return err
 		}
@@ -216,6 +230,8 @@ func (m *CrudResponse) contextValidateRead(ctx context.Context, formats strfmt.R
 		if err := m.Read.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("read")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("read")
 			}
 			return err
 		}
@@ -230,6 +246,8 @@ func (m *CrudResponse) contextValidateResult(ctx context.Context, formats strfmt
 		if err := m.Result.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("result")
 			}
 			return err
 		}
@@ -244,6 +262,8 @@ func (m *CrudResponse) contextValidateToken(ctx context.Context, formats strfmt.
 		if err := m.Token.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("token")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("token")
 			}
 			return err
 		}

--- a/swagger_models/crud_response_query.go
+++ b/swagger_models/crud_response_query.go
@@ -149,6 +149,8 @@ func (m *CrudResponseQuery) validateClazz(formats strfmt.Registry) error {
 		if err := m.Clazz.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("clazz")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("clazz")
 			}
 			return err
 		}
@@ -166,6 +168,8 @@ func (m *CrudResponseQuery) validateCode(formats strfmt.Registry) error {
 		if err := m.Code.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("code")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("code")
 			}
 			return err
 		}
@@ -183,6 +187,8 @@ func (m *CrudResponseQuery) validateCredentials(formats strfmt.Registry) error {
 		if err := m.Credentials.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("credentials")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("credentials")
 			}
 			return err
 		}
@@ -200,6 +206,8 @@ func (m *CrudResponseQuery) validateDocPolicies(formats strfmt.Registry) error {
 		if err := m.DocPolicies.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("docPolicies")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("docPolicies")
 			}
 			return err
 		}
@@ -217,6 +225,8 @@ func (m *CrudResponseQuery) validateEnterprises(formats strfmt.Registry) error {
 		if err := m.Enterprises.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("enterprises")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("enterprises")
 			}
 			return err
 		}
@@ -239,6 +249,8 @@ func (m *CrudResponseQuery) validateGlobalStatistics(formats strfmt.Registry) er
 			if err := m.GlobalStatistics[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("globalStatistics" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("globalStatistics" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -263,6 +275,8 @@ func (m *CrudResponseQuery) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -282,6 +296,8 @@ func (m *CrudResponseQuery) validatePolicies(formats strfmt.Registry) error {
 		if err := m.Policies.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("policies")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("policies")
 			}
 			return err
 		}
@@ -299,6 +315,8 @@ func (m *CrudResponseQuery) validateProfiles(formats strfmt.Registry) error {
 		if err := m.Profiles.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("profiles")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("profiles")
 			}
 			return err
 		}
@@ -321,6 +339,8 @@ func (m *CrudResponseQuery) validateQueryStatistics(formats strfmt.Registry) err
 			if err := m.QueryStatistics[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("queryStatistics" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("queryStatistics" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -340,6 +360,8 @@ func (m *CrudResponseQuery) validateQueryToken(formats strfmt.Registry) error {
 		if err := m.QueryToken.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("queryToken")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("queryToken")
 			}
 			return err
 		}
@@ -357,6 +379,8 @@ func (m *CrudResponseQuery) validateRealms(formats strfmt.Registry) error {
 		if err := m.Realms.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realms")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("realms")
 			}
 			return err
 		}
@@ -374,6 +398,8 @@ func (m *CrudResponseQuery) validateRoles(formats strfmt.Registry) error {
 		if err := m.Roles.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("roles")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("roles")
 			}
 			return err
 		}
@@ -391,6 +417,8 @@ func (m *CrudResponseQuery) validateUsers(formats strfmt.Registry) error {
 		if err := m.Users.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("users")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("users")
 			}
 			return err
 		}
@@ -471,6 +499,8 @@ func (m *CrudResponseQuery) contextValidateClazz(ctx context.Context, formats st
 		if err := m.Clazz.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("clazz")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("clazz")
 			}
 			return err
 		}
@@ -485,6 +515,8 @@ func (m *CrudResponseQuery) contextValidateCode(ctx context.Context, formats str
 		if err := m.Code.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("code")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("code")
 			}
 			return err
 		}
@@ -499,6 +531,8 @@ func (m *CrudResponseQuery) contextValidateCredentials(ctx context.Context, form
 		if err := m.Credentials.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("credentials")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("credentials")
 			}
 			return err
 		}
@@ -513,6 +547,8 @@ func (m *CrudResponseQuery) contextValidateDocPolicies(ctx context.Context, form
 		if err := m.DocPolicies.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("docPolicies")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("docPolicies")
 			}
 			return err
 		}
@@ -527,6 +563,8 @@ func (m *CrudResponseQuery) contextValidateEnterprises(ctx context.Context, form
 		if err := m.Enterprises.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("enterprises")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("enterprises")
 			}
 			return err
 		}
@@ -543,6 +581,8 @@ func (m *CrudResponseQuery) contextValidateGlobalStatistics(ctx context.Context,
 			if err := m.GlobalStatistics[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("globalStatistics" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("globalStatistics" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -561,6 +601,8 @@ func (m *CrudResponseQuery) contextValidateList(ctx context.Context, formats str
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -577,6 +619,8 @@ func (m *CrudResponseQuery) contextValidatePolicies(ctx context.Context, formats
 		if err := m.Policies.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("policies")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("policies")
 			}
 			return err
 		}
@@ -591,6 +635,8 @@ func (m *CrudResponseQuery) contextValidateProfiles(ctx context.Context, formats
 		if err := m.Profiles.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("profiles")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("profiles")
 			}
 			return err
 		}
@@ -607,6 +653,8 @@ func (m *CrudResponseQuery) contextValidateQueryStatistics(ctx context.Context, 
 			if err := m.QueryStatistics[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("queryStatistics" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("queryStatistics" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -623,6 +671,8 @@ func (m *CrudResponseQuery) contextValidateQueryToken(ctx context.Context, forma
 		if err := m.QueryToken.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("queryToken")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("queryToken")
 			}
 			return err
 		}
@@ -637,6 +687,8 @@ func (m *CrudResponseQuery) contextValidateRealms(ctx context.Context, formats s
 		if err := m.Realms.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("realms")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("realms")
 			}
 			return err
 		}
@@ -651,6 +703,8 @@ func (m *CrudResponseQuery) contextValidateRoles(ctx context.Context, formats st
 		if err := m.Roles.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("roles")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("roles")
 			}
 			return err
 		}
@@ -665,6 +719,8 @@ func (m *CrudResponseQuery) contextValidateUsers(ctx context.Context, formats st
 		if err := m.Users.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("users")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("users")
 			}
 			return err
 		}

--- a/swagger_models/crud_response_read.go
+++ b/swagger_models/crud_response_read.go
@@ -48,6 +48,8 @@ func (m *CrudResponseRead) validateResult(formats strfmt.Registry) error {
 		if err := m.Result.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("result")
 			}
 			return err
 		}
@@ -76,6 +78,8 @@ func (m *CrudResponseRead) contextValidateResult(ctx context.Context, formats st
 		if err := m.Result.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("result")
 			}
 			return err
 		}

--- a/swagger_models/crud_result_code.go
+++ b/swagger_models/crud_result_code.go
@@ -23,8 +23,12 @@ import (
 type CrudResultCode string
 
 func NewCrudResultCode(value CrudResultCode) *CrudResultCode {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated CrudResultCode.
+func (m CrudResultCode) Pointer() *CrudResultCode {
+	return &m
 }
 
 const (

--- a/swagger_models/crud_result_with_content.go
+++ b/swagger_models/crud_result_with_content.go
@@ -62,6 +62,8 @@ func (m *CrudResultWithContent) validateCode(formats strfmt.Registry) error {
 		if err := m.Code.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("code")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("code")
 			}
 			return err
 		}
@@ -79,6 +81,8 @@ func (m *CrudResultWithContent) validateContent(formats strfmt.Registry) error {
 		if err := m.Content.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("content")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("content")
 			}
 			return err
 		}
@@ -96,6 +100,8 @@ func (m *CrudResultWithContent) validateIdentifier(formats strfmt.Registry) erro
 		if err := m.Identifier.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("identifier")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("identifier")
 			}
 			return err
 		}
@@ -132,6 +138,8 @@ func (m *CrudResultWithContent) contextValidateCode(ctx context.Context, formats
 		if err := m.Code.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("code")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("code")
 			}
 			return err
 		}
@@ -146,6 +154,8 @@ func (m *CrudResultWithContent) contextValidateContent(ctx context.Context, form
 		if err := m.Content.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("content")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("content")
 			}
 			return err
 		}
@@ -160,6 +170,8 @@ func (m *CrudResultWithContent) contextValidateIdentifier(ctx context.Context, f
 		if err := m.Identifier.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("identifier")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("identifier")
 			}
 			return err
 		}

--- a/swagger_models/crud_statistics_container.go
+++ b/swagger_models/crud_statistics_container.go
@@ -55,6 +55,8 @@ func (m *CrudStatisticsContainer) validateClazz(formats strfmt.Registry) error {
 		if err := m.Clazz.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("clazz")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("clazz")
 			}
 			return err
 		}
@@ -72,6 +74,8 @@ func (m *CrudStatisticsContainer) validateUser(formats strfmt.Registry) error {
 		if err := m.User.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("user")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("user")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *CrudStatisticsContainer) contextValidateClazz(ctx context.Context, form
 		if err := m.Clazz.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("clazz")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("clazz")
 			}
 			return err
 		}
@@ -118,6 +124,8 @@ func (m *CrudStatisticsContainer) contextValidateUser(ctx context.Context, forma
 		if err := m.User.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("user")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("user")
 			}
 			return err
 		}

--- a/swagger_models/custom_config.go
+++ b/swagger_models/custom_config.go
@@ -72,6 +72,8 @@ func (m *CustomConfig) validateVariableGroups(formats strfmt.Registry) error {
 			if err := m.VariableGroups[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("variableGroups" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("variableGroups" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -104,6 +106,8 @@ func (m *CustomConfig) contextValidateVariableGroups(ctx context.Context, format
 			if err := m.VariableGroups[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("variableGroups" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("variableGroups" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/custom_config_variable_group.go
+++ b/swagger_models/custom_config_variable_group.go
@@ -62,6 +62,8 @@ func (m *CustomConfigVariableGroup) validateCondition(formats strfmt.Registry) e
 		if err := m.Condition.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("condition")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("condition")
 			}
 			return err
 		}
@@ -84,6 +86,8 @@ func (m *CustomConfigVariableGroup) validateVariables(formats strfmt.Registry) e
 			if err := m.Variables[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("variables" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("variables" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -118,6 +122,8 @@ func (m *CustomConfigVariableGroup) contextValidateCondition(ctx context.Context
 		if err := m.Condition.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("condition")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("condition")
 			}
 			return err
 		}
@@ -134,6 +140,8 @@ func (m *CustomConfigVariableGroup) contextValidateVariables(ctx context.Context
 			if err := m.Variables[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("variables" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("variables" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/custom_update_model_fields.go
+++ b/swagger_models/custom_update_model_fields.go
@@ -48,6 +48,8 @@ func (m *CustomUpdateModelFields) validateCustomModelAttributes(formats strfmt.R
 		if err := m.CustomModelAttributes.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("customModelAttributes")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("customModelAttributes")
 			}
 			return err
 		}
@@ -76,6 +78,8 @@ func (m *CustomUpdateModelFields) contextValidateCustomModelAttributes(ctx conte
 		if err := m.CustomModelAttributes.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("customModelAttributes")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("customModelAttributes")
 			}
 			return err
 		}

--- a/swagger_models/d_p_s_service_detail.go
+++ b/swagger_models/d_p_s_service_detail.go
@@ -55,6 +55,8 @@ func (m *DPSServiceDetail) validateEnrollment(formats strfmt.Registry) error {
 		if err := m.Enrollment.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("enrollment")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("enrollment")
 			}
 			return err
 		}
@@ -72,6 +74,8 @@ func (m *DPSServiceDetail) validateServiceDetail(formats strfmt.Registry) error 
 		if err := m.ServiceDetail.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("serviceDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("serviceDetail")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *DPSServiceDetail) contextValidateEnrollment(ctx context.Context, format
 		if err := m.Enrollment.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("enrollment")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("enrollment")
 			}
 			return err
 		}
@@ -118,6 +124,8 @@ func (m *DPSServiceDetail) contextValidateServiceDetail(ctx context.Context, for
 		if err := m.ServiceDetail.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("serviceDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("serviceDetail")
 			}
 			return err
 		}

--- a/swagger_models/datastore_filter.go
+++ b/swagger_models/datastore_filter.go
@@ -59,6 +59,8 @@ func (m *DatastoreFilter) validateDsType(formats strfmt.Registry) error {
 		if err := m.DsType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dsType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dsType")
 			}
 			return err
 		}
@@ -107,6 +109,8 @@ func (m *DatastoreFilter) contextValidateDsType(ctx context.Context, formats str
 		if err := m.DsType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dsType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dsType")
 			}
 			return err
 		}

--- a/swagger_models/datastore_info.go
+++ b/swagger_models/datastore_info.go
@@ -167,6 +167,8 @@ func (m *DatastoreInfo) validateCertificateChain(formats strfmt.Registry) error 
 		if err := m.CertificateChain.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("certificateChain")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("certificateChain")
 			}
 			return err
 		}
@@ -214,6 +216,8 @@ func (m *DatastoreInfo) validateDsStatus(formats strfmt.Registry) error {
 		if err := m.DsStatus.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dsStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dsStatus")
 			}
 			return err
 		}
@@ -236,6 +240,8 @@ func (m *DatastoreInfo) validateDsType(formats strfmt.Registry) error {
 		if err := m.DsType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dsType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dsType")
 			}
 			return err
 		}
@@ -286,6 +292,8 @@ func (m *DatastoreInfo) validateOriginType(formats strfmt.Registry) error {
 		if err := m.OriginType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -303,6 +311,8 @@ func (m *DatastoreInfo) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -320,6 +330,8 @@ func (m *DatastoreInfo) validateSecret(formats strfmt.Registry) error {
 		if err := m.Secret.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("secret")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("secret")
 			}
 			return err
 		}
@@ -401,6 +413,8 @@ func (m *DatastoreInfo) contextValidateCertificateChain(ctx context.Context, for
 		if err := m.CertificateChain.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("certificateChain")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("certificateChain")
 			}
 			return err
 		}
@@ -433,6 +447,8 @@ func (m *DatastoreInfo) contextValidateDsStatus(ctx context.Context, formats str
 		if err := m.DsStatus.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dsStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dsStatus")
 			}
 			return err
 		}
@@ -447,6 +463,8 @@ func (m *DatastoreInfo) contextValidateDsType(ctx context.Context, formats strfm
 		if err := m.DsType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dsType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dsType")
 			}
 			return err
 		}
@@ -470,6 +488,8 @@ func (m *DatastoreInfo) contextValidateOriginType(ctx context.Context, formats s
 		if err := m.OriginType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -484,6 +504,8 @@ func (m *DatastoreInfo) contextValidateRevision(ctx context.Context, formats str
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -498,6 +520,8 @@ func (m *DatastoreInfo) contextValidateSecret(ctx context.Context, formats strfm
 		if err := m.Secret.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("secret")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("secret")
 			}
 			return err
 		}

--- a/swagger_models/datastore_status.go
+++ b/swagger_models/datastore_status.go
@@ -23,8 +23,12 @@ import (
 type DatastoreStatus string
 
 func NewDatastoreStatus(value DatastoreStatus) *DatastoreStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated DatastoreStatus.
+func (m DatastoreStatus) Pointer() *DatastoreStatus {
+	return &m
 }
 
 const (

--- a/swagger_models/datastore_type.go
+++ b/swagger_models/datastore_type.go
@@ -33,8 +33,12 @@ import (
 type DatastoreType string
 
 func NewDatastoreType(value DatastoreType) *DatastoreType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated DatastoreType.
+func (m DatastoreType) Pointer() *DatastoreType {
+	return &m
 }
 
 const (

--- a/swagger_models/datastores.go
+++ b/swagger_models/datastores.go
@@ -75,6 +75,8 @@ func (m *Datastores) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -94,6 +96,8 @@ func (m *Datastores) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -111,6 +115,8 @@ func (m *Datastores) validateSummaryByCategory(formats strfmt.Registry) error {
 		if err := m.SummaryByCategory.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByCategory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByCategory")
 			}
 			return err
 		}
@@ -128,6 +134,8 @@ func (m *Datastores) validateSummaryByType(formats strfmt.Registry) error {
 		if err := m.SummaryByType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByType")
 			}
 			return err
 		}
@@ -170,6 +178,8 @@ func (m *Datastores) contextValidateList(ctx context.Context, formats strfmt.Reg
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -186,6 +196,8 @@ func (m *Datastores) contextValidateNext(ctx context.Context, formats strfmt.Reg
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -200,6 +212,8 @@ func (m *Datastores) contextValidateSummaryByCategory(ctx context.Context, forma
 		if err := m.SummaryByCategory.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByCategory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByCategory")
 			}
 			return err
 		}
@@ -214,6 +228,8 @@ func (m *Datastores) contextValidateSummaryByType(ctx context.Context, formats s
 		if err := m.SummaryByType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByType")
 			}
 			return err
 		}

--- a/swagger_models/decsription_code.go
+++ b/swagger_models/decsription_code.go
@@ -23,8 +23,12 @@ import (
 type DecsriptionCode string
 
 func NewDecsriptionCode(value DecsriptionCode) *DecsriptionCode {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated DecsriptionCode.
+func (m DecsriptionCode) Pointer() *DecsriptionCode {
+	return &m
 }
 
 const (

--- a/swagger_models/deployment_type.go
+++ b/swagger_models/deployment_type.go
@@ -23,8 +23,12 @@ import (
 type DeploymentType string
 
 func NewDeploymentType(value DeploymentType) *DeploymentType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated DeploymentType.
+func (m DeploymentType) Pointer() *DeploymentType {
+	return &m
 }
 
 const (

--- a/swagger_models/description.go
+++ b/swagger_models/description.go
@@ -56,6 +56,8 @@ func (m *Description) validateDescCode(formats strfmt.Registry) error {
 		if err := m.DescCode.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("descCode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("descCode")
 			}
 			return err
 		}
@@ -88,6 +90,8 @@ func (m *Description) contextValidateDescCode(ctx context.Context, formats strfm
 		if err := m.DescCode.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("descCode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("descCode")
 			}
 			return err
 		}

--- a/swagger_models/detailed_user.go
+++ b/swagger_models/detailed_user.go
@@ -206,6 +206,8 @@ func (m *DetailedUser) validateAllowedEnterprises(formats strfmt.Registry) error
 			if err := m.AllowedEnterprises[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("allowedEnterprises" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("allowedEnterprises" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -234,6 +236,8 @@ func (m *DetailedUser) validateEmailState(formats strfmt.Registry) error {
 		if err := m.EmailState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("emailState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("emailState")
 			}
 			return err
 		}
@@ -263,6 +267,8 @@ func (m *DetailedUser) validatePhoneState(formats strfmt.Registry) error {
 		if err := m.PhoneState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("phoneState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("phoneState")
 			}
 			return err
 		}
@@ -280,6 +286,8 @@ func (m *DetailedUser) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -310,6 +318,8 @@ func (m *DetailedUser) validateState(formats strfmt.Registry) error {
 		if err := m.State.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("state")
 			}
 			return err
 		}
@@ -327,6 +337,8 @@ func (m *DetailedUser) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -406,6 +418,8 @@ func (m *DetailedUser) contextValidateAllowedEnterprises(ctx context.Context, fo
 			if err := m.AllowedEnterprises[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("allowedEnterprises" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("allowedEnterprises" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -422,6 +436,8 @@ func (m *DetailedUser) contextValidateEmailState(ctx context.Context, formats st
 		if err := m.EmailState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("emailState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("emailState")
 			}
 			return err
 		}
@@ -454,6 +470,8 @@ func (m *DetailedUser) contextValidatePhoneState(ctx context.Context, formats st
 		if err := m.PhoneState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("phoneState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("phoneState")
 			}
 			return err
 		}
@@ -468,6 +486,8 @@ func (m *DetailedUser) contextValidateRevision(ctx context.Context, formats strf
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -482,6 +502,8 @@ func (m *DetailedUser) contextValidateState(ctx context.Context, formats strfmt.
 		if err := m.State.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("state")
 			}
 			return err
 		}
@@ -496,6 +518,8 @@ func (m *DetailedUser) contextValidateType(ctx context.Context, formats strfmt.R
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/detailed_users.go
+++ b/swagger_models/detailed_users.go
@@ -68,6 +68,8 @@ func (m *DetailedUsers) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *DetailedUsers) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *DetailedUsers) validateSummaryByState(formats strfmt.Registry) error {
 		if err := m.SummaryByState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *DetailedUsers) contextValidateList(ctx context.Context, formats strfmt.
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -158,6 +166,8 @@ func (m *DetailedUsers) contextValidateNext(ctx context.Context, formats strfmt.
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *DetailedUsers) contextValidateSummaryByState(ctx context.Context, forma
 		if err := m.SummaryByState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}

--- a/swagger_models/details.go
+++ b/swagger_models/details.go
@@ -83,6 +83,8 @@ func (m *Details) validateAppCategory(formats strfmt.Registry) error {
 		if err := m.AppCategory.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appCategory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appCategory")
 			}
 			return err
 		}
@@ -111,6 +113,8 @@ func (m *Details) contextValidateAppCategory(ctx context.Context, formats strfmt
 		if err := m.AppCategory.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appCategory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appCategory")
 			}
 			return err
 		}

--- a/swagger_models/dev_data_sec_at_rest.go
+++ b/swagger_models/dev_data_sec_at_rest.go
@@ -58,6 +58,8 @@ func (m *DevDataSecAtRest) validateErrInfo(formats strfmt.Registry) error {
 		if err := m.ErrInfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("errInfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("errInfo")
 			}
 			return err
 		}
@@ -75,6 +77,8 @@ func (m *DevDataSecAtRest) validateStatus(formats strfmt.Registry) error {
 		if err := m.Status.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}
@@ -107,6 +111,8 @@ func (m *DevDataSecAtRest) contextValidateErrInfo(ctx context.Context, formats s
 		if err := m.ErrInfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("errInfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("errInfo")
 			}
 			return err
 		}
@@ -121,6 +127,8 @@ func (m *DevDataSecAtRest) contextValidateStatus(ctx context.Context, formats st
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}

--- a/swagger_models/device_boot_reason.go
+++ b/swagger_models/device_boot_reason.go
@@ -23,8 +23,12 @@ import (
 type DeviceBootReason string
 
 func NewDeviceBootReason(value DeviceBootReason) *DeviceBootReason {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated DeviceBootReason.
+func (m DeviceBootReason) Pointer() *DeviceBootReason {
+	return &m
 }
 
 const (

--- a/swagger_models/device_cmds_sub_type.go
+++ b/swagger_models/device_cmds_sub_type.go
@@ -35,8 +35,12 @@ import (
 type DeviceCmdsSubType string
 
 func NewDeviceCmdsSubType(value DeviceCmdsSubType) *DeviceCmdsSubType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated DeviceCmdsSubType.
+func (m DeviceCmdsSubType) Pointer() *DeviceCmdsSubType {
+	return &m
 }
 
 const (

--- a/swagger_models/device_config.go
+++ b/swagger_models/device_config.go
@@ -211,6 +211,8 @@ func (m *DeviceConfig) validateAdminState(formats strfmt.Registry) error {
 		if err := m.AdminState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("adminState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("adminState")
 			}
 			return err
 		}
@@ -233,6 +235,8 @@ func (m *DeviceConfig) validateBaseImage(formats strfmt.Registry) error {
 			if err := m.BaseImage[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("baseImage" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("baseImage" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -277,6 +281,8 @@ func (m *DeviceConfig) validateConfigItem(formats strfmt.Registry) error {
 			if err := m.ConfigItem[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("configItem" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("configItem" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -296,6 +302,8 @@ func (m *DeviceConfig) validateDevLocation(formats strfmt.Registry) error {
 		if err := m.DevLocation.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("devLocation")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("devLocation")
 			}
 			return err
 		}
@@ -313,6 +321,8 @@ func (m *DeviceConfig) validateDlisp(formats strfmt.Registry) error {
 		if err := m.Dlisp.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dlisp")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dlisp")
 			}
 			return err
 		}
@@ -347,6 +357,8 @@ func (m *DeviceConfig) validateInterfaces(formats strfmt.Registry) error {
 			if err := m.Interfaces[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("interfaces" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("interfaces" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -384,6 +396,8 @@ func (m *DeviceConfig) validateOnboarding(formats strfmt.Registry) error {
 		if err := m.Onboarding.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("onboarding")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("onboarding")
 			}
 			return err
 		}
@@ -410,6 +424,8 @@ func (m *DeviceConfig) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -436,6 +452,8 @@ func (m *DeviceConfig) validateUtype(formats strfmt.Registry) error {
 		if err := m.Utype.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("utype")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("utype")
 			}
 			return err
 		}
@@ -500,6 +518,8 @@ func (m *DeviceConfig) contextValidateAdminState(ctx context.Context, formats st
 		if err := m.AdminState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("adminState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("adminState")
 			}
 			return err
 		}
@@ -516,6 +536,8 @@ func (m *DeviceConfig) contextValidateBaseImage(ctx context.Context, formats str
 			if err := m.BaseImage[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("baseImage" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("baseImage" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -534,6 +556,8 @@ func (m *DeviceConfig) contextValidateConfigItem(ctx context.Context, formats st
 			if err := m.ConfigItem[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("configItem" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("configItem" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -550,6 +574,8 @@ func (m *DeviceConfig) contextValidateDevLocation(ctx context.Context, formats s
 		if err := m.DevLocation.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("devLocation")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("devLocation")
 			}
 			return err
 		}
@@ -564,6 +590,8 @@ func (m *DeviceConfig) contextValidateDlisp(ctx context.Context, formats strfmt.
 		if err := m.Dlisp.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dlisp")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dlisp")
 			}
 			return err
 		}
@@ -589,6 +617,8 @@ func (m *DeviceConfig) contextValidateInterfaces(ctx context.Context, formats st
 			if err := m.Interfaces[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("interfaces" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("interfaces" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -605,6 +635,8 @@ func (m *DeviceConfig) contextValidateOnboarding(ctx context.Context, formats st
 		if err := m.Onboarding.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("onboarding")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("onboarding")
 			}
 			return err
 		}
@@ -619,6 +651,8 @@ func (m *DeviceConfig) contextValidateRevision(ctx context.Context, formats strf
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -633,6 +667,8 @@ func (m *DeviceConfig) contextValidateUtype(ctx context.Context, formats strfmt.
 		if err := m.Utype.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("utype")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("utype")
 			}
 			return err
 		}

--- a/swagger_models/device_config_list.go
+++ b/swagger_models/device_config_list.go
@@ -75,6 +75,8 @@ func (m *DeviceConfigList) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -95,6 +97,8 @@ func (m *DeviceConfigList) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -113,6 +117,8 @@ func (m *DeviceConfigList) validateSummaryByState(formats strfmt.Registry) error
 		if err := m.SummaryByState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -151,6 +157,8 @@ func (m *DeviceConfigList) contextValidateList(ctx context.Context, formats strf
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -167,6 +175,8 @@ func (m *DeviceConfigList) contextValidateNext(ctx context.Context, formats strf
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -181,6 +191,8 @@ func (m *DeviceConfigList) contextValidateSummaryByState(ctx context.Context, fo
 		if err := m.SummaryByState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}

--- a/swagger_models/device_config_summary.go
+++ b/swagger_models/device_config_summary.go
@@ -133,6 +133,8 @@ func (m *DeviceConfigSummary) validateAdminState(formats strfmt.Registry) error 
 		if err := m.AdminState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("adminState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("adminState")
 			}
 			return err
 		}
@@ -155,6 +157,8 @@ func (m *DeviceConfigSummary) validateBaseImage(formats strfmt.Registry) error {
 			if err := m.BaseImage[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("baseImage" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("baseImage" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -211,6 +215,8 @@ func (m *DeviceConfigSummary) validateInterfaces(formats strfmt.Registry) error 
 			if err := m.Interfaces[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("interfaces" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("interfaces" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -266,6 +272,8 @@ func (m *DeviceConfigSummary) validateUtype(formats strfmt.Registry) error {
 		if err := m.Utype.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("utype")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("utype")
 			}
 			return err
 		}
@@ -310,6 +318,8 @@ func (m *DeviceConfigSummary) contextValidateAdminState(ctx context.Context, for
 		if err := m.AdminState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("adminState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("adminState")
 			}
 			return err
 		}
@@ -326,6 +336,8 @@ func (m *DeviceConfigSummary) contextValidateBaseImage(ctx context.Context, form
 			if err := m.BaseImage[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("baseImage" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("baseImage" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -353,6 +365,8 @@ func (m *DeviceConfigSummary) contextValidateInterfaces(ctx context.Context, for
 			if err := m.Interfaces[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("interfaces" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("interfaces" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -369,6 +383,8 @@ func (m *DeviceConfigSummary) contextValidateUtype(ctx context.Context, formats 
 		if err := m.Utype.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("utype")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("utype")
 			}
 			return err
 		}

--- a/swagger_models/device_data_security_at_rest_status.go
+++ b/swagger_models/device_data_security_at_rest_status.go
@@ -23,8 +23,12 @@ import (
 type DeviceDataSecurityAtRestStatus string
 
 func NewDeviceDataSecurityAtRestStatus(value DeviceDataSecurityAtRestStatus) *DeviceDataSecurityAtRestStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated DeviceDataSecurityAtRestStatus.
+func (m DeviceDataSecurityAtRestStatus) Pointer() *DeviceDataSecurityAtRestStatus {
+	return &m
 }
 
 const (

--- a/swagger_models/device_entity.go
+++ b/swagger_models/device_entity.go
@@ -51,6 +51,8 @@ func (m *DeviceEntity) validateEntity(formats strfmt.Registry) error {
 		if err := m.Entity.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("entity")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("entity")
 			}
 			return err
 		}
@@ -79,6 +81,8 @@ func (m *DeviceEntity) contextValidateEntity(ctx context.Context, formats strfmt
 		if err := m.Entity.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("entity")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("entity")
 			}
 			return err
 		}

--- a/swagger_models/device_error.go
+++ b/swagger_models/device_error.go
@@ -95,6 +95,8 @@ func (m *DeviceError) validateEntities(formats strfmt.Registry) error {
 			if err := m.Entities[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("entities" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("entities" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -119,6 +121,8 @@ func (m *DeviceError) validateSeverity(formats strfmt.Registry) error {
 		if err := m.Severity.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("severity")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("severity")
 			}
 			return err
 		}
@@ -162,6 +166,8 @@ func (m *DeviceError) contextValidateEntities(ctx context.Context, formats strfm
 			if err := m.Entities[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("entities" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("entities" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -178,6 +184,8 @@ func (m *DeviceError) contextValidateSeverity(ctx context.Context, formats strfm
 		if err := m.Severity.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("severity")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("severity")
 			}
 			return err
 		}

--- a/swagger_models/device_h_w_security_module_status.go
+++ b/swagger_models/device_h_w_security_module_status.go
@@ -23,8 +23,12 @@ import (
 type DeviceHWSecurityModuleStatus string
 
 func NewDeviceHWSecurityModuleStatus(value DeviceHWSecurityModuleStatus) *DeviceHWSecurityModuleStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated DeviceHWSecurityModuleStatus.
+func (m DeviceHWSecurityModuleStatus) Pointer() *DeviceHWSecurityModuleStatus {
+	return &m
 }
 
 const (

--- a/swagger_models/device_lisp.go
+++ b/swagger_models/device_lisp.go
@@ -178,6 +178,8 @@ func (m *DeviceLisp) validateLispMapServers(formats strfmt.Registry) error {
 			if err := m.LispMapServers[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("lispMapServers" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("lispMapServers" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -212,6 +214,8 @@ func (m *DeviceLisp) validateZedServers(formats strfmt.Registry) error {
 			if err := m.ZedServers[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("zedServers" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("zedServers" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -248,6 +252,8 @@ func (m *DeviceLisp) contextValidateLispMapServers(ctx context.Context, formats 
 			if err := m.LispMapServers[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("lispMapServers" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("lispMapServers" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -266,6 +272,8 @@ func (m *DeviceLisp) contextValidateZedServers(ctx context.Context, formats strf
 			if err := m.ZedServers[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("zedServers" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("zedServers" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/device_load.go
+++ b/swagger_models/device_load.go
@@ -23,8 +23,12 @@ import (
 type DeviceLoad string
 
 func NewDeviceLoad(value DeviceLoad) *DeviceLoad {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated DeviceLoad.
+func (m DeviceLoad) Pointer() *DeviceLoad {
+	return &m
 }
 
 const (

--- a/swagger_models/device_s_w_info.go
+++ b/swagger_models/device_s_w_info.go
@@ -96,6 +96,8 @@ func (m *DeviceSWInfo) validateStatus(formats strfmt.Registry) error {
 		if err := m.Status.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}
@@ -113,6 +115,8 @@ func (m *DeviceSWInfo) validateSwError(formats strfmt.Registry) error {
 		if err := m.SwError.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("swError")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("swError")
 			}
 			return err
 		}
@@ -130,6 +134,8 @@ func (m *DeviceSWInfo) validateSwStatus(formats strfmt.Registry) error {
 		if err := m.SwStatus.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("swStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("swStatus")
 			}
 			return err
 		}
@@ -147,6 +153,8 @@ func (m *DeviceSWInfo) validateSwSubStatus(formats strfmt.Registry) error {
 		if err := m.SwSubStatus.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("swSubStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("swSubStatus")
 			}
 			return err
 		}
@@ -187,6 +195,8 @@ func (m *DeviceSWInfo) contextValidateStatus(ctx context.Context, formats strfmt
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}
@@ -201,6 +211,8 @@ func (m *DeviceSWInfo) contextValidateSwError(ctx context.Context, formats strfm
 		if err := m.SwError.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("swError")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("swError")
 			}
 			return err
 		}
@@ -215,6 +227,8 @@ func (m *DeviceSWInfo) contextValidateSwStatus(ctx context.Context, formats strf
 		if err := m.SwStatus.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("swStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("swStatus")
 			}
 			return err
 		}
@@ -229,6 +243,8 @@ func (m *DeviceSWInfo) contextValidateSwSubStatus(ctx context.Context, formats s
 		if err := m.SwSubStatus.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("swSubStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("swSubStatus")
 			}
 			return err
 		}

--- a/swagger_models/device_s_w_status.go
+++ b/swagger_models/device_s_w_status.go
@@ -23,8 +23,12 @@ import (
 type DeviceSWStatus string
 
 func NewDeviceSWStatus(value DeviceSWStatus) *DeviceSWStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated DeviceSWStatus.
+func (m DeviceSWStatus) Pointer() *DeviceSWStatus {
+	return &m
 }
 
 const (

--- a/swagger_models/device_s_w_sub_status.go
+++ b/swagger_models/device_s_w_sub_status.go
@@ -23,8 +23,12 @@ import (
 type DeviceSWSubStatus string
 
 func NewDeviceSWSubStatus(value DeviceSWSubStatus) *DeviceSWSubStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated DeviceSWSubStatus.
+func (m DeviceSWSubStatus) Pointer() *DeviceSWSubStatus {
+	return &m
 }
 
 const (

--- a/swagger_models/device_status_filter.go
+++ b/swagger_models/device_status_filter.go
@@ -64,6 +64,8 @@ func (m *DeviceStatusFilter) validateLoad(formats strfmt.Registry) error {
 		if err := m.Load.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("load")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("load")
 			}
 			return err
 		}
@@ -81,6 +83,8 @@ func (m *DeviceStatusFilter) validateRunState(formats strfmt.Registry) error {
 		if err := m.RunState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -113,6 +117,8 @@ func (m *DeviceStatusFilter) contextValidateLoad(ctx context.Context, formats st
 		if err := m.Load.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("load")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("load")
 			}
 			return err
 		}
@@ -127,6 +133,8 @@ func (m *DeviceStatusFilter) contextValidateRunState(ctx context.Context, format
 		if err := m.RunState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}

--- a/swagger_models/device_status_list_msg.go
+++ b/swagger_models/device_status_list_msg.go
@@ -85,6 +85,8 @@ func (m *DeviceStatusListMsg) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -104,6 +106,8 @@ func (m *DeviceStatusListMsg) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -121,6 +125,8 @@ func (m *DeviceStatusListMsg) validateSummaryByAppInstanceCount(formats strfmt.R
 		if err := m.SummaryByAppInstanceCount.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByAppInstanceCount")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByAppInstanceCount")
 			}
 			return err
 		}
@@ -138,6 +144,8 @@ func (m *DeviceStatusListMsg) validateSummaryByEVEDistribution(formats strfmt.Re
 		if err := m.SummaryByEVEDistribution.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByEVEDistribution")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByEVEDistribution")
 			}
 			return err
 		}
@@ -155,6 +163,8 @@ func (m *DeviceStatusListMsg) validateSummaryByState(formats strfmt.Registry) er
 		if err := m.SummaryByState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -201,6 +211,8 @@ func (m *DeviceStatusListMsg) contextValidateList(ctx context.Context, formats s
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -217,6 +229,8 @@ func (m *DeviceStatusListMsg) contextValidateNext(ctx context.Context, formats s
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -231,6 +245,8 @@ func (m *DeviceStatusListMsg) contextValidateSummaryByAppInstanceCount(ctx conte
 		if err := m.SummaryByAppInstanceCount.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByAppInstanceCount")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByAppInstanceCount")
 			}
 			return err
 		}
@@ -245,6 +261,8 @@ func (m *DeviceStatusListMsg) contextValidateSummaryByEVEDistribution(ctx contex
 		if err := m.SummaryByEVEDistribution.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByEVEDistribution")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByEVEDistribution")
 			}
 			return err
 		}
@@ -259,6 +277,8 @@ func (m *DeviceStatusListMsg) contextValidateSummaryByState(ctx context.Context,
 		if err := m.SummaryByState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}

--- a/swagger_models/device_status_msg.go
+++ b/swagger_models/device_status_msg.go
@@ -261,6 +261,8 @@ func (m *DeviceStatusMsg) validateCPU(formats strfmt.Registry) error {
 		if err := m.CPU.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Cpu")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Cpu")
 			}
 			return err
 		}
@@ -278,6 +280,8 @@ func (m *DeviceStatusMsg) validateMemory(formats strfmt.Registry) error {
 		if err := m.Memory.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Memory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Memory")
 			}
 			return err
 		}
@@ -295,6 +299,8 @@ func (m *DeviceStatusMsg) validateStorage(formats strfmt.Registry) error {
 		if err := m.Storage.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Storage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Storage")
 			}
 			return err
 		}
@@ -312,6 +318,8 @@ func (m *DeviceStatusMsg) validateAdminState(formats strfmt.Registry) error {
 		if err := m.AdminState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("adminState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("adminState")
 			}
 			return err
 		}
@@ -329,6 +337,8 @@ func (m *DeviceStatusMsg) validateAttestState(formats strfmt.Registry) error {
 		if err := m.AttestState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("attestState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("attestState")
 			}
 			return err
 		}
@@ -351,6 +361,8 @@ func (m *DeviceStatusMsg) validateBlobList(formats strfmt.Registry) error {
 			if err := m.BlobList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("blobList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("blobList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -382,6 +394,8 @@ func (m *DeviceStatusMsg) validateCapabilities(formats strfmt.Registry) error {
 		if err := m.Capabilities.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("capabilities")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("capabilities")
 			}
 			return err
 		}
@@ -424,6 +438,8 @@ func (m *DeviceStatusMsg) validateDataSecInfo(formats strfmt.Registry) error {
 			if err := m.DataSecInfo[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("dataSecInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("dataSecInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -448,6 +464,8 @@ func (m *DeviceStatusMsg) validateDevError(formats strfmt.Registry) error {
 			if err := m.DevError[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("devError" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("devError" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -467,6 +485,8 @@ func (m *DeviceStatusMsg) validateDeviceRebootReason(formats strfmt.Registry) er
 		if err := m.DeviceRebootReason.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deviceRebootReason")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deviceRebootReason")
 			}
 			return err
 		}
@@ -484,6 +504,8 @@ func (m *DeviceStatusMsg) validateDinfo(formats strfmt.Registry) error {
 		if err := m.Dinfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dinfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dinfo")
 			}
 			return err
 		}
@@ -501,6 +523,8 @@ func (m *DeviceStatusMsg) validateDNS(formats strfmt.Registry) error {
 		if err := m.DNS.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dns")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dns")
 			}
 			return err
 		}
@@ -523,6 +547,8 @@ func (m *DeviceStatusMsg) validateIoStatusList(formats strfmt.Registry) error {
 			if err := m.IoStatusList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("ioStatusList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("ioStatusList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -566,6 +592,8 @@ func (m *DeviceStatusMsg) validateMemorySummary(formats strfmt.Registry) error {
 		if err := m.MemorySummary.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("memorySummary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("memorySummary")
 			}
 			return err
 		}
@@ -583,6 +611,8 @@ func (m *DeviceStatusMsg) validateMinfo(formats strfmt.Registry) error {
 		if err := m.Minfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("minfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("minfo")
 			}
 			return err
 		}
@@ -605,6 +635,8 @@ func (m *DeviceStatusMsg) validateNetCounterList(formats strfmt.Registry) error 
 			if err := m.NetCounterList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("netCounterList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("netCounterList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -629,6 +661,8 @@ func (m *DeviceStatusMsg) validateNetStatusList(formats strfmt.Registry) error {
 			if err := m.NetStatusList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("netStatusList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("netStatusList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -648,6 +682,8 @@ func (m *DeviceStatusMsg) validateRunState(formats strfmt.Registry) error {
 		if err := m.RunState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -670,6 +706,8 @@ func (m *DeviceStatusMsg) validateStorageList(formats strfmt.Registry) error {
 			if err := m.StorageList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("storageList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("storageList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -694,6 +732,8 @@ func (m *DeviceStatusMsg) validateSwInfo(formats strfmt.Registry) error {
 			if err := m.SwInfo[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("swInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("swInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -730,6 +770,8 @@ func (m *DeviceStatusMsg) validateZcCounters(formats strfmt.Registry) error {
 			if err := m.ZcCounters[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("zcCounters" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("zcCounters" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -840,6 +882,8 @@ func (m *DeviceStatusMsg) contextValidateCPU(ctx context.Context, formats strfmt
 		if err := m.CPU.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Cpu")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Cpu")
 			}
 			return err
 		}
@@ -854,6 +898,8 @@ func (m *DeviceStatusMsg) contextValidateMemory(ctx context.Context, formats str
 		if err := m.Memory.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Memory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Memory")
 			}
 			return err
 		}
@@ -868,6 +914,8 @@ func (m *DeviceStatusMsg) contextValidateStorage(ctx context.Context, formats st
 		if err := m.Storage.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Storage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Storage")
 			}
 			return err
 		}
@@ -882,6 +930,8 @@ func (m *DeviceStatusMsg) contextValidateAdminState(ctx context.Context, formats
 		if err := m.AdminState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("adminState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("adminState")
 			}
 			return err
 		}
@@ -896,6 +946,8 @@ func (m *DeviceStatusMsg) contextValidateAttestState(ctx context.Context, format
 		if err := m.AttestState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("attestState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("attestState")
 			}
 			return err
 		}
@@ -912,6 +964,8 @@ func (m *DeviceStatusMsg) contextValidateBlobList(ctx context.Context, formats s
 			if err := m.BlobList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("blobList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("blobList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -928,6 +982,8 @@ func (m *DeviceStatusMsg) contextValidateCapabilities(ctx context.Context, forma
 		if err := m.Capabilities.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("capabilities")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("capabilities")
 			}
 			return err
 		}
@@ -944,6 +1000,8 @@ func (m *DeviceStatusMsg) contextValidateDataSecInfo(ctx context.Context, format
 			if err := m.DataSecInfo[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("dataSecInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("dataSecInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -962,6 +1020,8 @@ func (m *DeviceStatusMsg) contextValidateDevError(ctx context.Context, formats s
 			if err := m.DevError[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("devError" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("devError" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -978,6 +1038,8 @@ func (m *DeviceStatusMsg) contextValidateDeviceRebootReason(ctx context.Context,
 		if err := m.DeviceRebootReason.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deviceRebootReason")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deviceRebootReason")
 			}
 			return err
 		}
@@ -992,6 +1054,8 @@ func (m *DeviceStatusMsg) contextValidateDinfo(ctx context.Context, formats strf
 		if err := m.Dinfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dinfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dinfo")
 			}
 			return err
 		}
@@ -1006,6 +1070,8 @@ func (m *DeviceStatusMsg) contextValidateDNS(ctx context.Context, formats strfmt
 		if err := m.DNS.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dns")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dns")
 			}
 			return err
 		}
@@ -1022,6 +1088,8 @@ func (m *DeviceStatusMsg) contextValidateIoStatusList(ctx context.Context, forma
 			if err := m.IoStatusList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("ioStatusList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("ioStatusList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -1038,6 +1106,8 @@ func (m *DeviceStatusMsg) contextValidateMemorySummary(ctx context.Context, form
 		if err := m.MemorySummary.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("memorySummary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("memorySummary")
 			}
 			return err
 		}
@@ -1052,6 +1122,8 @@ func (m *DeviceStatusMsg) contextValidateMinfo(ctx context.Context, formats strf
 		if err := m.Minfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("minfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("minfo")
 			}
 			return err
 		}
@@ -1068,6 +1140,8 @@ func (m *DeviceStatusMsg) contextValidateNetCounterList(ctx context.Context, for
 			if err := m.NetCounterList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("netCounterList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("netCounterList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -1086,6 +1160,8 @@ func (m *DeviceStatusMsg) contextValidateNetStatusList(ctx context.Context, form
 			if err := m.NetStatusList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("netStatusList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("netStatusList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -1102,6 +1178,8 @@ func (m *DeviceStatusMsg) contextValidateRunState(ctx context.Context, formats s
 		if err := m.RunState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -1118,6 +1196,8 @@ func (m *DeviceStatusMsg) contextValidateStorageList(ctx context.Context, format
 			if err := m.StorageList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("storageList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("storageList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -1136,6 +1216,8 @@ func (m *DeviceStatusMsg) contextValidateSwInfo(ctx context.Context, formats str
 			if err := m.SwInfo[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("swInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("swInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -1154,6 +1236,8 @@ func (m *DeviceStatusMsg) contextValidateZcCounters(ctx context.Context, formats
 			if err := m.ZcCounters[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("zcCounters" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("zcCounters" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/device_status_summary_msg.go
+++ b/swagger_models/device_status_summary_msg.go
@@ -145,6 +145,8 @@ func (m *DeviceStatusSummaryMsg) validateCPU(formats strfmt.Registry) error {
 		if err := m.CPU.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Cpu")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Cpu")
 			}
 			return err
 		}
@@ -162,6 +164,8 @@ func (m *DeviceStatusSummaryMsg) validateMemory(formats strfmt.Registry) error {
 		if err := m.Memory.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Memory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Memory")
 			}
 			return err
 		}
@@ -179,6 +183,8 @@ func (m *DeviceStatusSummaryMsg) validateStorage(formats strfmt.Registry) error 
 		if err := m.Storage.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Storage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Storage")
 			}
 			return err
 		}
@@ -196,6 +202,8 @@ func (m *DeviceStatusSummaryMsg) validateAdminState(formats strfmt.Registry) err
 		if err := m.AdminState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("adminState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("adminState")
 			}
 			return err
 		}
@@ -238,6 +246,8 @@ func (m *DeviceStatusSummaryMsg) validateDevError(formats strfmt.Registry) error
 			if err := m.DevError[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("devError" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("devError" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -257,6 +267,8 @@ func (m *DeviceStatusSummaryMsg) validateDinfo(formats strfmt.Registry) error {
 		if err := m.Dinfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dinfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dinfo")
 			}
 			return err
 		}
@@ -274,6 +286,8 @@ func (m *DeviceStatusSummaryMsg) validateMemorySummary(formats strfmt.Registry) 
 		if err := m.MemorySummary.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("memorySummary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("memorySummary")
 			}
 			return err
 		}
@@ -291,6 +305,8 @@ func (m *DeviceStatusSummaryMsg) validateMinfo(formats strfmt.Registry) error {
 		if err := m.Minfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("minfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("minfo")
 			}
 			return err
 		}
@@ -313,6 +329,8 @@ func (m *DeviceStatusSummaryMsg) validateNetStatusList(formats strfmt.Registry) 
 			if err := m.NetStatusList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("netStatusList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("netStatusList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -332,6 +350,8 @@ func (m *DeviceStatusSummaryMsg) validateRunState(formats strfmt.Registry) error
 		if err := m.RunState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -354,6 +374,8 @@ func (m *DeviceStatusSummaryMsg) validateSwInfo(formats strfmt.Registry) error {
 			if err := m.SwInfo[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("swInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("swInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -424,6 +446,8 @@ func (m *DeviceStatusSummaryMsg) contextValidateCPU(ctx context.Context, formats
 		if err := m.CPU.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Cpu")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Cpu")
 			}
 			return err
 		}
@@ -438,6 +462,8 @@ func (m *DeviceStatusSummaryMsg) contextValidateMemory(ctx context.Context, form
 		if err := m.Memory.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Memory")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Memory")
 			}
 			return err
 		}
@@ -452,6 +478,8 @@ func (m *DeviceStatusSummaryMsg) contextValidateStorage(ctx context.Context, for
 		if err := m.Storage.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("Storage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("Storage")
 			}
 			return err
 		}
@@ -466,6 +494,8 @@ func (m *DeviceStatusSummaryMsg) contextValidateAdminState(ctx context.Context, 
 		if err := m.AdminState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("adminState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("adminState")
 			}
 			return err
 		}
@@ -482,6 +512,8 @@ func (m *DeviceStatusSummaryMsg) contextValidateDevError(ctx context.Context, fo
 			if err := m.DevError[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("devError" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("devError" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -498,6 +530,8 @@ func (m *DeviceStatusSummaryMsg) contextValidateDinfo(ctx context.Context, forma
 		if err := m.Dinfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dinfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dinfo")
 			}
 			return err
 		}
@@ -512,6 +546,8 @@ func (m *DeviceStatusSummaryMsg) contextValidateMemorySummary(ctx context.Contex
 		if err := m.MemorySummary.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("memorySummary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("memorySummary")
 			}
 			return err
 		}
@@ -526,6 +562,8 @@ func (m *DeviceStatusSummaryMsg) contextValidateMinfo(ctx context.Context, forma
 		if err := m.Minfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("minfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("minfo")
 			}
 			return err
 		}
@@ -542,6 +580,8 @@ func (m *DeviceStatusSummaryMsg) contextValidateNetStatusList(ctx context.Contex
 			if err := m.NetStatusList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("netStatusList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("netStatusList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -558,6 +598,8 @@ func (m *DeviceStatusSummaryMsg) contextValidateRunState(ctx context.Context, fo
 		if err := m.RunState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -574,6 +616,8 @@ func (m *DeviceStatusSummaryMsg) contextValidateSwInfo(ctx context.Context, form
 			if err := m.SwInfo[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("swInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("swInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/dhcp_server_config.go
+++ b/swagger_models/dhcp_server_config.go
@@ -67,6 +67,8 @@ func (m *DhcpServerConfig) validateDhcpRange(formats strfmt.Registry) error {
 		if err := m.DhcpRange.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dhcpRange")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dhcpRange")
 			}
 			return err
 		}
@@ -95,6 +97,8 @@ func (m *DhcpServerConfig) contextValidateDhcpRange(ctx context.Context, formats
 		if err := m.DhcpRange.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dhcpRange")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dhcpRange")
 			}
 			return err
 		}

--- a/swagger_models/doc_policies.go
+++ b/swagger_models/doc_policies.go
@@ -68,6 +68,8 @@ func (m *DocPolicies) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *DocPolicies) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *DocPolicies) validateSummaryByState(formats strfmt.Registry) error {
 		if err := m.SummaryByState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *DocPolicies) contextValidateList(ctx context.Context, formats strfmt.Re
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -158,6 +166,8 @@ func (m *DocPolicies) contextValidateNext(ctx context.Context, formats strfmt.Re
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *DocPolicies) contextValidateSummaryByState(ctx context.Context, formats
 		if err := m.SummaryByState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}

--- a/swagger_models/doc_policy.go
+++ b/swagger_models/doc_policy.go
@@ -117,6 +117,8 @@ func (m *DocPolicy) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -158,6 +160,8 @@ func (m *DocPolicy) contextValidateRevision(ctx context.Context, formats strfmt.
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}

--- a/swagger_models/doc_policy_summary.go
+++ b/swagger_models/doc_policy_summary.go
@@ -88,6 +88,8 @@ func (m *DocPolicySummary) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -116,6 +118,8 @@ func (m *DocPolicySummary) contextValidateRevision(ctx context.Context, formats 
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}

--- a/swagger_models/e_id_register.go
+++ b/swagger_models/e_id_register.go
@@ -199,6 +199,8 @@ func (m *EIDRegister) validateLispMapServers(formats strfmt.Registry) error {
 			if err := m.LispMapServers[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("LispMapServers" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("LispMapServers" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -249,6 +251,8 @@ func (m *EIDRegister) contextValidateLispMapServers(ctx context.Context, formats
 			if err := m.LispMapServers[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("LispMapServers" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("LispMapServers" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/enrollment_detail.go
+++ b/swagger_models/enrollment_detail.go
@@ -81,6 +81,8 @@ func (m *EnrollmentDetail) validateAllocationPolicy(formats strfmt.Registry) err
 		if err := m.AllocationPolicy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("allocationPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("allocationPolicy")
 			}
 			return err
 		}
@@ -98,6 +100,8 @@ func (m *EnrollmentDetail) validateMechanism(formats strfmt.Registry) error {
 		if err := m.Mechanism.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("mechanism")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("mechanism")
 			}
 			return err
 		}
@@ -115,6 +119,8 @@ func (m *EnrollmentDetail) validateSymmetricKeyEnrollment(formats strfmt.Registr
 		if err := m.SymmetricKeyEnrollment.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("symmetricKeyEnrollment")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("symmetricKeyEnrollment")
 			}
 			return err
 		}
@@ -132,6 +138,8 @@ func (m *EnrollmentDetail) validateTpmEnrollment(formats strfmt.Registry) error 
 		if err := m.TpmEnrollment.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("tpmEnrollment")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("tpmEnrollment")
 			}
 			return err
 		}
@@ -172,6 +180,8 @@ func (m *EnrollmentDetail) contextValidateAllocationPolicy(ctx context.Context, 
 		if err := m.AllocationPolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("allocationPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("allocationPolicy")
 			}
 			return err
 		}
@@ -186,6 +196,8 @@ func (m *EnrollmentDetail) contextValidateMechanism(ctx context.Context, formats
 		if err := m.Mechanism.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("mechanism")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("mechanism")
 			}
 			return err
 		}
@@ -200,6 +212,8 @@ func (m *EnrollmentDetail) contextValidateSymmetricKeyEnrollment(ctx context.Con
 		if err := m.SymmetricKeyEnrollment.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("symmetricKeyEnrollment")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("symmetricKeyEnrollment")
 			}
 			return err
 		}
@@ -214,6 +228,8 @@ func (m *EnrollmentDetail) contextValidateTpmEnrollment(ctx context.Context, for
 		if err := m.TpmEnrollment.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("tpmEnrollment")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("tpmEnrollment")
 			}
 			return err
 		}

--- a/swagger_models/enrollment_mechanism.go
+++ b/swagger_models/enrollment_mechanism.go
@@ -23,8 +23,12 @@ import (
 type EnrollmentMechanism string
 
 func NewEnrollmentMechanism(value EnrollmentMechanism) *EnrollmentMechanism {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated EnrollmentMechanism.
+func (m EnrollmentMechanism) Pointer() *EnrollmentMechanism {
+	return &m
 }
 
 const (

--- a/swagger_models/enrollment_type.go
+++ b/swagger_models/enrollment_type.go
@@ -23,8 +23,12 @@ import (
 type EnrollmentType string
 
 func NewEnrollmentType(value EnrollmentType) *EnrollmentType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated EnrollmentType.
+func (m EnrollmentType) Pointer() *EnrollmentType {
+	return &m
 }
 
 const (

--- a/swagger_models/enterprise.go
+++ b/swagger_models/enterprise.go
@@ -154,6 +154,8 @@ func (m *Enterprise) validateChildEnterprises(formats strfmt.Registry) error {
 			if err := m.ChildEnterprises[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("childEnterprises" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("childEnterprises" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -230,6 +232,8 @@ func (m *Enterprise) validatePolicyList(formats strfmt.Registry) error {
 		if err := m.PolicyList.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("policyList")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("policyList")
 			}
 			return err
 		}
@@ -247,6 +251,8 @@ func (m *Enterprise) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -264,6 +270,8 @@ func (m *Enterprise) validateState(formats strfmt.Registry) error {
 		if err := m.State.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("state")
 			}
 			return err
 		}
@@ -302,6 +310,8 @@ func (m *Enterprise) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -352,6 +362,8 @@ func (m *Enterprise) contextValidateChildEnterprises(ctx context.Context, format
 			if err := m.ChildEnterprises[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("childEnterprises" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("childEnterprises" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -377,6 +389,8 @@ func (m *Enterprise) contextValidatePolicyList(ctx context.Context, formats strf
 		if err := m.PolicyList.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("policyList")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("policyList")
 			}
 			return err
 		}
@@ -391,6 +405,8 @@ func (m *Enterprise) contextValidateRevision(ctx context.Context, formats strfmt
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -405,6 +421,8 @@ func (m *Enterprise) contextValidateState(ctx context.Context, formats strfmt.Re
 		if err := m.State.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("state")
 			}
 			return err
 		}
@@ -419,6 +437,8 @@ func (m *Enterprise) contextValidateType(ctx context.Context, formats strfmt.Reg
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/enterprise_state.go
+++ b/swagger_models/enterprise_state.go
@@ -23,8 +23,12 @@ import (
 type EnterpriseState string
 
 func NewEnterpriseState(value EnterpriseState) *EnterpriseState {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated EnterpriseState.
+func (m EnterpriseState) Pointer() *EnterpriseState {
+	return &m
 }
 
 const (

--- a/swagger_models/enterprise_type.go
+++ b/swagger_models/enterprise_type.go
@@ -23,8 +23,12 @@ import (
 type EnterpriseType string
 
 func NewEnterpriseType(value EnterpriseType) *EnterpriseType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated EnterpriseType.
+func (m EnterpriseType) Pointer() *EnterpriseType {
+	return &m
 }
 
 const (

--- a/swagger_models/enterprises.go
+++ b/swagger_models/enterprises.go
@@ -68,6 +68,8 @@ func (m *Enterprises) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *Enterprises) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *Enterprises) validateSummaryByState(formats strfmt.Registry) error {
 		if err := m.SummaryByState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *Enterprises) contextValidateList(ctx context.Context, formats strfmt.Re
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -158,6 +166,8 @@ func (m *Enterprises) contextValidateNext(ctx context.Context, formats strfmt.Re
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *Enterprises) contextValidateSummaryByState(ctx context.Context, formats
 		if err := m.SummaryByState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}

--- a/swagger_models/entity.go
+++ b/swagger_models/entity.go
@@ -36,8 +36,12 @@ import (
 type Entity string
 
 func NewEntity(value Entity) *Entity {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated Entity.
+func (m Entity) Pointer() *Entity {
+	return &m
 }
 
 const (

--- a/swagger_models/eveconfig_image.go
+++ b/swagger_models/eveconfig_image.go
@@ -75,6 +75,8 @@ func (m *EveconfigImage) validateIformat(formats strfmt.Registry) error {
 		if err := m.Iformat.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("iformat")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("iformat")
 			}
 			return err
 		}
@@ -92,6 +94,8 @@ func (m *EveconfigImage) validateSiginfo(formats strfmt.Registry) error {
 		if err := m.Siginfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("siginfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("siginfo")
 			}
 			return err
 		}
@@ -109,6 +113,8 @@ func (m *EveconfigImage) validateUuidandversion(formats strfmt.Registry) error {
 		if err := m.Uuidandversion.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("uuidandversion")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("uuidandversion")
 			}
 			return err
 		}
@@ -145,6 +151,8 @@ func (m *EveconfigImage) contextValidateIformat(ctx context.Context, formats str
 		if err := m.Iformat.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("iformat")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("iformat")
 			}
 			return err
 		}
@@ -159,6 +167,8 @@ func (m *EveconfigImage) contextValidateSiginfo(ctx context.Context, formats str
 		if err := m.Siginfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("siginfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("siginfo")
 			}
 			return err
 		}
@@ -173,6 +183,8 @@ func (m *EveconfigImage) contextValidateUuidandversion(ctx context.Context, form
 		if err := m.Uuidandversion.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("uuidandversion")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("uuidandversion")
 			}
 			return err
 		}

--- a/swagger_models/event_query_response.go
+++ b/swagger_models/event_query_response.go
@@ -67,6 +67,8 @@ func (m *EventQueryResponse) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *EventQueryResponse) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -121,6 +125,8 @@ func (m *EventQueryResponse) contextValidateList(ctx context.Context, formats st
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -137,6 +143,8 @@ func (m *EventQueryResponse) contextValidateNext(ctx context.Context, formats st
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}

--- a/swagger_models/event_query_response_item.go
+++ b/swagger_models/event_query_response_item.go
@@ -89,6 +89,8 @@ func (m *EventQueryResponseItem) validateSource(formats strfmt.Registry) error {
 		if err := m.Source.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("source")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("source")
 			}
 			return err
 		}
@@ -117,6 +119,8 @@ func (m *EventQueryResponseItem) contextValidateSource(ctx context.Context, form
 		if err := m.Source.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("source")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("source")
 			}
 			return err
 		}

--- a/swagger_models/event_source.go
+++ b/swagger_models/event_source.go
@@ -27,8 +27,12 @@ import (
 type EventSource string
 
 func NewEventSource(value EventSource) *EventSource {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated EventSource.
+func (m EventSource) Pointer() *EventSource {
+	return &m
 }
 
 const (

--- a/swagger_models/flowlog_action.go
+++ b/swagger_models/flowlog_action.go
@@ -23,8 +23,12 @@ import (
 type FlowlogAction string
 
 func NewFlowlogAction(value FlowlogAction) *FlowlogAction {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated FlowlogAction.
+func (m FlowlogAction) Pointer() *FlowlogAction {
+	return &m
 }
 
 const (

--- a/swagger_models/flowlog_category_type.go
+++ b/swagger_models/flowlog_category_type.go
@@ -23,8 +23,12 @@ import (
 type FlowlogCategoryType string
 
 func NewFlowlogCategoryType(value FlowlogCategoryType) *FlowlogCategoryType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated FlowlogCategoryType.
+func (m FlowlogCategoryType) Pointer() *FlowlogCategoryType {
+	return &m
 }
 
 const (

--- a/swagger_models/flowlog_direction.go
+++ b/swagger_models/flowlog_direction.go
@@ -23,8 +23,12 @@ import (
 type FlowlogDirection string
 
 func NewFlowlogDirection(value FlowlogDirection) *FlowlogDirection {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated FlowlogDirection.
+func (m FlowlogDirection) Pointer() *FlowlogDirection {
+	return &m
 }
 
 const (

--- a/swagger_models/flowlog_metric.go
+++ b/swagger_models/flowlog_metric.go
@@ -23,8 +23,12 @@ import (
 type FlowlogMetric string
 
 func NewFlowlogMetric(value FlowlogMetric) *FlowlogMetric {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated FlowlogMetric.
+func (m FlowlogMetric) Pointer() *FlowlogMetric {
+	return &m
 }
 
 const (

--- a/swagger_models/health_desc.go
+++ b/swagger_models/health_desc.go
@@ -60,6 +60,8 @@ func (m *HealthDesc) validateBriefHealth(formats strfmt.Registry) error {
 		if err := m.BriefHealth.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("briefHealth")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("briefHealth")
 			}
 			return err
 		}
@@ -88,6 +90,8 @@ func (m *HealthDesc) contextValidateBriefHealth(ctx context.Context, formats str
 		if err := m.BriefHealth.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("briefHealth")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("briefHealth")
 			}
 			return err
 		}

--- a/swagger_models/health_service_resp.go
+++ b/swagger_models/health_service_resp.go
@@ -68,6 +68,8 @@ func (m *HealthServiceResp) validateHealthDesc(formats strfmt.Registry) error {
 			if err := m.HealthDesc[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("healthDesc" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("healthDesc" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *HealthServiceResp) validateHealthService(formats strfmt.Registry) error
 		if err := m.HealthService.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("healthService")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("healthService")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *HealthServiceResp) validateHresult(formats strfmt.Registry) error {
 		if err := m.Hresult.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("hresult")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("hresult")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *HealthServiceResp) contextValidateHealthDesc(ctx context.Context, forma
 			if err := m.HealthDesc[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("healthDesc" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("healthDesc" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -158,6 +166,8 @@ func (m *HealthServiceResp) contextValidateHealthService(ctx context.Context, fo
 		if err := m.HealthService.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("healthService")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("healthService")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *HealthServiceResp) contextValidateHresult(ctx context.Context, formats 
 		if err := m.Hresult.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("hresult")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("hresult")
 			}
 			return err
 		}

--- a/swagger_models/health_service_sub_type.go
+++ b/swagger_models/health_service_sub_type.go
@@ -23,8 +23,12 @@ import (
 type HealthServiceSubType string
 
 func NewHealthServiceSubType(value HealthServiceSubType) *HealthServiceSubType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated HealthServiceSubType.
+func (m HealthServiceSubType) Pointer() *HealthServiceSubType {
+	return &m
 }
 
 const (

--- a/swagger_models/hv_mode.go
+++ b/swagger_models/hv_mode.go
@@ -26,8 +26,12 @@ import (
 type HvMode string
 
 func NewHvMode(value HvMode) *HvMode {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated HvMode.
+func (m HvMode) Pointer() *HvMode {
+	return &m
 }
 
 const (

--- a/swagger_models/id_state.go
+++ b/swagger_models/id_state.go
@@ -23,8 +23,12 @@ import (
 type IDState string
 
 func NewIDState(value IDState) *IDState {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated IDState.
+func (m IDState) Pointer() *IDState {
+	return &m
 }
 
 const (

--- a/swagger_models/image_config.go
+++ b/swagger_models/image_config.go
@@ -202,6 +202,8 @@ func (m *ImageConfig) validateImageArch(formats strfmt.Registry) error {
 		if err := m.ImageArch.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imageArch")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("imageArch")
 			}
 			return err
 		}
@@ -224,6 +226,8 @@ func (m *ImageConfig) validateImageFormat(formats strfmt.Registry) error {
 		if err := m.ImageFormat.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imageFormat")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("imageFormat")
 			}
 			return err
 		}
@@ -241,6 +245,8 @@ func (m *ImageConfig) validateImageStatus(formats strfmt.Registry) error {
 		if err := m.ImageStatus.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imageStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("imageStatus")
 			}
 			return err
 		}
@@ -263,6 +269,8 @@ func (m *ImageConfig) validateImageType(formats strfmt.Registry) error {
 		if err := m.ImageType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imageType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("imageType")
 			}
 			return err
 		}
@@ -301,6 +309,8 @@ func (m *ImageConfig) validateOriginType(formats strfmt.Registry) error {
 		if err := m.OriginType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -318,6 +328,8 @@ func (m *ImageConfig) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -408,6 +420,8 @@ func (m *ImageConfig) contextValidateImageArch(ctx context.Context, formats strf
 		if err := m.ImageArch.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imageArch")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("imageArch")
 			}
 			return err
 		}
@@ -431,6 +445,8 @@ func (m *ImageConfig) contextValidateImageFormat(ctx context.Context, formats st
 		if err := m.ImageFormat.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imageFormat")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("imageFormat")
 			}
 			return err
 		}
@@ -454,6 +470,8 @@ func (m *ImageConfig) contextValidateImageStatus(ctx context.Context, formats st
 		if err := m.ImageStatus.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imageStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("imageStatus")
 			}
 			return err
 		}
@@ -468,6 +486,8 @@ func (m *ImageConfig) contextValidateImageType(ctx context.Context, formats strf
 		if err := m.ImageType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imageType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("imageType")
 			}
 			return err
 		}
@@ -482,6 +502,8 @@ func (m *ImageConfig) contextValidateOriginType(ctx context.Context, formats str
 		if err := m.OriginType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -496,6 +518,8 @@ func (m *ImageConfig) contextValidateRevision(ctx context.Context, formats strfm
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}

--- a/swagger_models/image_filter.go
+++ b/swagger_models/image_filter.go
@@ -93,6 +93,8 @@ func (m *ImageFilter) validateImageArch(formats strfmt.Registry) error {
 		if err := m.ImageArch.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imageArch")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("imageArch")
 			}
 			return err
 		}
@@ -110,6 +112,8 @@ func (m *ImageFilter) validateImageStatus(formats strfmt.Registry) error {
 		if err := m.ImageStatus.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imageStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("imageStatus")
 			}
 			return err
 		}
@@ -127,6 +131,8 @@ func (m *ImageFilter) validateImageType(formats strfmt.Registry) error {
 		if err := m.ImageType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imageType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("imageType")
 			}
 			return err
 		}
@@ -183,6 +189,8 @@ func (m *ImageFilter) contextValidateImageArch(ctx context.Context, formats strf
 		if err := m.ImageArch.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imageArch")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("imageArch")
 			}
 			return err
 		}
@@ -197,6 +205,8 @@ func (m *ImageFilter) contextValidateImageStatus(ctx context.Context, formats st
 		if err := m.ImageStatus.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imageStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("imageStatus")
 			}
 			return err
 		}
@@ -211,6 +221,8 @@ func (m *ImageFilter) contextValidateImageType(ctx context.Context, formats strf
 		if err := m.ImageType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imageType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("imageType")
 			}
 			return err
 		}

--- a/swagger_models/image_status.go
+++ b/swagger_models/image_status.go
@@ -30,8 +30,12 @@ import (
 type ImageStatus string
 
 func NewImageStatus(value ImageStatus) *ImageStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ImageStatus.
+func (m ImageStatus) Pointer() *ImageStatus {
+	return &m
 }
 
 const (

--- a/swagger_models/image_type.go
+++ b/swagger_models/image_type.go
@@ -27,8 +27,12 @@ import (
 type ImageType string
 
 func NewImageType(value ImageType) *ImageType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ImageType.
+func (m ImageType) Pointer() *ImageType {
+	return &m
 }
 
 const (

--- a/swagger_models/images.go
+++ b/swagger_models/images.go
@@ -68,6 +68,8 @@ func (m *Images) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *Images) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *Images) validateTerse(formats strfmt.Registry) error {
 		if err := m.Terse.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("terse")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("terse")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *Images) contextValidateList(ctx context.Context, formats strfmt.Registr
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -158,6 +166,8 @@ func (m *Images) contextValidateNext(ctx context.Context, formats strfmt.Registr
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *Images) contextValidateTerse(ctx context.Context, formats strfmt.Regist
 		if err := m.Terse.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("terse")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("terse")
 			}
 			return err
 		}

--- a/swagger_models/instance_transition_action.go
+++ b/swagger_models/instance_transition_action.go
@@ -33,8 +33,12 @@ import (
 type InstanceTransitionAction string
 
 func NewInstanceTransitionAction(value InstanceTransitionAction) *InstanceTransitionAction {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated InstanceTransitionAction.
+func (m InstanceTransitionAction) Pointer() *InstanceTransitionAction {
+	return &m
 }
 
 const (

--- a/swagger_models/interface.go
+++ b/swagger_models/interface.go
@@ -69,6 +69,8 @@ func (m *Interface) validateAcls(formats strfmt.Registry) error {
 			if err := m.Acls[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("acls" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("acls" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -101,6 +103,8 @@ func (m *Interface) contextValidateAcls(ctx context.Context, formats strfmt.Regi
 			if err := m.Acls[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("acls" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("acls" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/io_bundle_status.go
+++ b/swagger_models/io_bundle_status.go
@@ -101,6 +101,8 @@ func (m *IoBundleStatus) validateErr(formats strfmt.Registry) error {
 		if err := m.Err.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("err")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("err")
 			}
 			return err
 		}
@@ -118,6 +120,8 @@ func (m *IoBundleStatus) validateLteInfo(formats strfmt.Registry) error {
 		if err := m.LteInfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("lte_info")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("lte_info")
 			}
 			return err
 		}
@@ -158,6 +162,8 @@ func (m *IoBundleStatus) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -194,6 +200,8 @@ func (m *IoBundleStatus) contextValidateErr(ctx context.Context, formats strfmt.
 		if err := m.Err.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("err")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("err")
 			}
 			return err
 		}
@@ -208,6 +216,8 @@ func (m *IoBundleStatus) contextValidateLteInfo(ctx context.Context, formats str
 		if err := m.LteInfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("lte_info")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("lte_info")
 			}
 			return err
 		}
@@ -222,6 +232,8 @@ func (m *IoBundleStatus) contextValidateType(ctx context.Context, formats strfmt
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/io_member.go
+++ b/swagger_models/io_member.go
@@ -155,6 +155,8 @@ func (m *IoMember) validateUsage(formats strfmt.Registry) error {
 		if err := m.Usage.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("usage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("usage")
 			}
 			return err
 		}
@@ -177,6 +179,8 @@ func (m *IoMember) validateZtype(formats strfmt.Registry) error {
 		if err := m.Ztype.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ztype")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ztype")
 			}
 			return err
 		}
@@ -209,6 +213,8 @@ func (m *IoMember) contextValidateUsage(ctx context.Context, formats strfmt.Regi
 		if err := m.Usage.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("usage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("usage")
 			}
 			return err
 		}
@@ -223,6 +229,8 @@ func (m *IoMember) contextValidateZtype(ctx context.Context, formats strfmt.Regi
 		if err := m.Ztype.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ztype")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ztype")
 			}
 			return err
 		}

--- a/swagger_models/io_type.go
+++ b/swagger_models/io_type.go
@@ -34,8 +34,12 @@ import (
 type IoType string
 
 func NewIoType(value IoType) *IoType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated IoType.
+func (m IoType) Pointer() *IoType {
+	return &m
 }
 
 const (

--- a/swagger_models/iot_hub_service_detail.go
+++ b/swagger_models/iot_hub_service_detail.go
@@ -48,6 +48,8 @@ func (m *IotHubServiceDetail) validateServiceDetail(formats strfmt.Registry) err
 		if err := m.ServiceDetail.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("serviceDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("serviceDetail")
 			}
 			return err
 		}
@@ -76,6 +78,8 @@ func (m *IotHubServiceDetail) contextValidateServiceDetail(ctx context.Context, 
 		if err := m.ServiceDetail.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("serviceDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("serviceDetail")
 			}
 			return err
 		}

--- a/swagger_models/ip_spec.go
+++ b/swagger_models/ip_spec.go
@@ -77,6 +77,8 @@ func (m *IPSpec) validateDhcp(formats strfmt.Registry) error {
 		if err := m.Dhcp.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dhcp")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dhcp")
 			}
 			return err
 		}
@@ -94,6 +96,8 @@ func (m *IPSpec) validateDhcpRange(formats strfmt.Registry) error {
 		if err := m.DhcpRange.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dhcpRange")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dhcpRange")
 			}
 			return err
 		}
@@ -126,6 +130,8 @@ func (m *IPSpec) contextValidateDhcp(ctx context.Context, formats strfmt.Registr
 		if err := m.Dhcp.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dhcp")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dhcp")
 			}
 			return err
 		}
@@ -140,6 +146,8 @@ func (m *IPSpec) contextValidateDhcpRange(ctx context.Context, formats strfmt.Re
 		if err := m.DhcpRange.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dhcpRange")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dhcpRange")
 			}
 			return err
 		}

--- a/swagger_models/job_config.go
+++ b/swagger_models/job_config.go
@@ -191,6 +191,8 @@ func (m *JobConfig) validateObjectType(formats strfmt.Registry) error {
 		if err := m.ObjectType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("objectType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("objectType")
 			}
 			return err
 		}
@@ -208,6 +210,8 @@ func (m *JobConfig) validateOperationType(formats strfmt.Registry) error {
 		if err := m.OperationType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("operationType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("operationType")
 			}
 			return err
 		}
@@ -225,6 +229,8 @@ func (m *JobConfig) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -242,6 +248,8 @@ func (m *JobConfig) validateSelectionCriteria(formats strfmt.Registry) error {
 		if err := m.SelectionCriteria.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("selectionCriteria")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("selectionCriteria")
 			}
 			return err
 		}
@@ -271,6 +279,8 @@ func (m *JobConfig) validateStatus(formats strfmt.Registry) error {
 		if err := m.Status.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}
@@ -358,6 +368,8 @@ func (m *JobConfig) contextValidateObjectType(ctx context.Context, formats strfm
 		if err := m.ObjectType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("objectType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("objectType")
 			}
 			return err
 		}
@@ -372,6 +384,8 @@ func (m *JobConfig) contextValidateOperationType(ctx context.Context, formats st
 		if err := m.OperationType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("operationType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("operationType")
 			}
 			return err
 		}
@@ -386,6 +400,8 @@ func (m *JobConfig) contextValidateRevision(ctx context.Context, formats strfmt.
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -400,6 +416,8 @@ func (m *JobConfig) contextValidateSelectionCriteria(ctx context.Context, format
 		if err := m.SelectionCriteria.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("selectionCriteria")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("selectionCriteria")
 			}
 			return err
 		}
@@ -423,6 +441,8 @@ func (m *JobConfig) contextValidateStatus(ctx context.Context, formats strfmt.Re
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}

--- a/swagger_models/job_config_list.go
+++ b/swagger_models/job_config_list.go
@@ -65,6 +65,8 @@ func (m *JobConfigList) validateJobListSummary(formats strfmt.Registry) error {
 		if err := m.JobListSummary.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("jobListSummary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("jobListSummary")
 			}
 			return err
 		}
@@ -87,6 +89,8 @@ func (m *JobConfigList) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -106,6 +110,8 @@ func (m *JobConfigList) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *JobConfigList) contextValidateJobListSummary(ctx context.Context, forma
 		if err := m.JobListSummary.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("jobListSummary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("jobListSummary")
 			}
 			return err
 		}
@@ -158,6 +166,8 @@ func (m *JobConfigList) contextValidateList(ctx context.Context, formats strfmt.
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -174,6 +184,8 @@ func (m *JobConfigList) contextValidateNext(ctx context.Context, formats strfmt.
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}

--- a/swagger_models/job_filter.go
+++ b/swagger_models/job_filter.go
@@ -62,6 +62,8 @@ func (m *JobFilter) validateJobStatus(formats strfmt.Registry) error {
 		if err := m.JobStatus.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("jobStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("jobStatus")
 			}
 			return err
 		}
@@ -102,6 +104,8 @@ func (m *JobFilter) contextValidateJobStatus(ctx context.Context, formats strfmt
 		if err := m.JobStatus.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("jobStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("jobStatus")
 			}
 			return err
 		}

--- a/swagger_models/job_status.go
+++ b/swagger_models/job_status.go
@@ -23,8 +23,12 @@ import (
 type JobStatus string
 
 func NewJobStatus(value JobStatus) *JobStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated JobStatus.
+func (m JobStatus) Pointer() *JobStatus {
+	return &m
 }
 
 const (

--- a/swagger_models/l_t_e_adapter.go
+++ b/swagger_models/l_t_e_adapter.go
@@ -68,6 +68,8 @@ func (m *LTEAdapter) validateSimcardState(formats strfmt.Registry) error {
 		if err := m.SimcardState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("simcard_state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("simcard_state")
 			}
 			return err
 		}
@@ -96,6 +98,8 @@ func (m *LTEAdapter) contextValidateSimcardState(ctx context.Context, formats st
 		if err := m.SimcardState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("simcard_state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("simcard_state")
 			}
 			return err
 		}

--- a/swagger_models/lisp_config.go
+++ b/swagger_models/lisp_config.go
@@ -72,6 +72,8 @@ func (m *LispConfig) validateSp(formats strfmt.Registry) error {
 			if err := m.Sp[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("sp" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("sp" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -104,6 +106,8 @@ func (m *LispConfig) contextValidateSp(ctx context.Context, formats strfmt.Regis
 			if err := m.Sp[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("sp" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("sp" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/manifest_info.go
+++ b/swagger_models/manifest_info.go
@@ -66,6 +66,8 @@ func (m *ManifestInfo) validateDetails(formats strfmt.Registry) error {
 		if err := m.Details.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("details")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("details")
 			}
 			return err
 		}
@@ -83,6 +85,8 @@ func (m *ManifestInfo) validateTransitionAction(formats strfmt.Registry) error {
 		if err := m.TransitionAction.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("transitionAction")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("transitionAction")
 			}
 			return err
 		}
@@ -115,6 +119,8 @@ func (m *ManifestInfo) contextValidateDetails(ctx context.Context, formats strfm
 		if err := m.Details.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("details")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("details")
 			}
 			return err
 		}
@@ -129,6 +135,8 @@ func (m *ManifestInfo) contextValidateTransitionAction(ctx context.Context, form
 		if err := m.TransitionAction.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("transitionAction")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("transitionAction")
 			}
 			return err
 		}

--- a/swagger_models/metric_query_response.go
+++ b/swagger_models/metric_query_response.go
@@ -70,6 +70,8 @@ func (m *MetricQueryResponse) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -89,6 +91,8 @@ func (m *MetricQueryResponse) validateThreshold(formats strfmt.Registry) error {
 		if err := m.Threshold.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("threshold")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("threshold")
 			}
 			return err
 		}
@@ -123,6 +127,8 @@ func (m *MetricQueryResponse) contextValidateList(ctx context.Context, formats s
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -139,6 +145,8 @@ func (m *MetricQueryResponse) contextValidateThreshold(ctx context.Context, form
 		if err := m.Threshold.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("threshold")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("threshold")
 			}
 			return err
 		}

--- a/swagger_models/metric_type.go
+++ b/swagger_models/metric_type.go
@@ -23,8 +23,12 @@ import (
 type MetricType string
 
 func NewMetricType(value MetricType) *MetricType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MetricType.
+func (m MetricType) Pointer() *MetricType {
+	return &m
 }
 
 const (

--- a/swagger_models/model_arch_type.go
+++ b/swagger_models/model_arch_type.go
@@ -23,8 +23,12 @@ import (
 type ModelArchType string
 
 func NewModelArchType(value ModelArchType) *ModelArchType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ModelArchType.
+func (m ModelArchType) Pointer() *ModelArchType {
+	return &m
 }
 
 const (

--- a/swagger_models/model_clazz.go
+++ b/swagger_models/model_clazz.go
@@ -23,8 +23,12 @@ import (
 type ModelClazz string
 
 func NewModelClazz(value ModelClazz) *ModelClazz {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ModelClazz.
+func (m ModelClazz) Pointer() *ModelClazz {
+	return &m
 }
 
 const (

--- a/swagger_models/model_import.go
+++ b/swagger_models/model_import.go
@@ -54,6 +54,8 @@ func (m *ModelImport) validateModelConfig(formats strfmt.Registry) error {
 			if err := m.ModelConfig[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("modelConfig" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("modelConfig" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -86,6 +88,8 @@ func (m *ModelImport) contextValidateModelConfig(ctx context.Context, formats st
 			if err := m.ModelConfig[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("modelConfig" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("modelConfig" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/module_detail.go
+++ b/swagger_models/module_detail.go
@@ -60,6 +60,8 @@ func (m *ModuleDetail) validateModuleType(formats strfmt.Registry) error {
 		if err := m.ModuleType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("moduleType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("moduleType")
 			}
 			return err
 		}
@@ -88,6 +90,8 @@ func (m *ModuleDetail) contextValidateModuleType(ctx context.Context, formats st
 		if err := m.ModuleType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("moduleType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("moduleType")
 			}
 			return err
 		}

--- a/swagger_models/module_policy.go
+++ b/swagger_models/module_policy.go
@@ -93,6 +93,8 @@ func (m *ModulePolicy) validateApps(formats strfmt.Registry) error {
 			if err := m.Apps[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("apps" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("apps" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -124,6 +126,8 @@ func (m *ModulePolicy) validateMetrics(formats strfmt.Registry) error {
 		if err := m.Metrics.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("metrics")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("metrics")
 			}
 			return err
 		}
@@ -162,6 +166,8 @@ func (m *ModulePolicy) contextValidateApps(ctx context.Context, formats strfmt.R
 			if err := m.Apps[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("apps" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("apps" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -187,6 +193,8 @@ func (m *ModulePolicy) contextValidateMetrics(ctx context.Context, formats strfm
 		if err := m.Metrics.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("metrics")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("metrics")
 			}
 			return err
 		}

--- a/swagger_models/module_summary.go
+++ b/swagger_models/module_summary.go
@@ -50,6 +50,8 @@ func (m *ModuleSummary) validateModuleType(formats strfmt.Registry) error {
 		if err := m.ModuleType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("moduleType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("moduleType")
 			}
 			return err
 		}
@@ -78,6 +80,8 @@ func (m *ModuleSummary) contextValidateModuleType(ctx context.Context, formats s
 		if err := m.ModuleType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("moduleType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("moduleType")
 			}
 			return err
 		}

--- a/swagger_models/module_type.go
+++ b/swagger_models/module_type.go
@@ -23,8 +23,12 @@ import (
 type ModuleType string
 
 func NewModuleType(value ModuleType) *ModuleType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ModuleType.
+func (m ModuleType) Pointer() *ModuleType {
+	return &m
 }
 
 const (

--- a/swagger_models/net_config.go
+++ b/swagger_models/net_config.go
@@ -156,6 +156,8 @@ func (m *NetConfig) validateDNSList(formats strfmt.Registry) error {
 			if err := m.DNSList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("dnsList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("dnsList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -188,6 +190,8 @@ func (m *NetConfig) validateIP(formats strfmt.Registry) error {
 		if err := m.IP.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ip")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ip")
 			}
 			return err
 		}
@@ -210,6 +214,8 @@ func (m *NetConfig) validateKind(formats strfmt.Registry) error {
 		if err := m.Kind.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kind")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("kind")
 			}
 			return err
 		}
@@ -257,6 +263,8 @@ func (m *NetConfig) validateProxy(formats strfmt.Registry) error {
 		if err := m.Proxy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("proxy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("proxy")
 			}
 			return err
 		}
@@ -274,6 +282,8 @@ func (m *NetConfig) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -312,6 +322,8 @@ func (m *NetConfig) validateWireless(formats strfmt.Registry) error {
 		if err := m.Wireless.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("wireless")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("wireless")
 			}
 			return err
 		}
@@ -366,6 +378,8 @@ func (m *NetConfig) contextValidateDNSList(ctx context.Context, formats strfmt.R
 			if err := m.DNSList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("dnsList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("dnsList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -391,6 +405,8 @@ func (m *NetConfig) contextValidateIP(ctx context.Context, formats strfmt.Regist
 		if err := m.IP.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ip")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ip")
 			}
 			return err
 		}
@@ -405,6 +421,8 @@ func (m *NetConfig) contextValidateKind(ctx context.Context, formats strfmt.Regi
 		if err := m.Kind.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kind")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("kind")
 			}
 			return err
 		}
@@ -419,6 +437,8 @@ func (m *NetConfig) contextValidateProxy(ctx context.Context, formats strfmt.Reg
 		if err := m.Proxy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("proxy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("proxy")
 			}
 			return err
 		}
@@ -433,6 +453,8 @@ func (m *NetConfig) contextValidateRevision(ctx context.Context, formats strfmt.
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -447,6 +469,8 @@ func (m *NetConfig) contextValidateWireless(ctx context.Context, formats strfmt.
 		if err := m.Wireless.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("wireless")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("wireless")
 			}
 			return err
 		}

--- a/swagger_models/net_config_list.go
+++ b/swagger_models/net_config_list.go
@@ -68,6 +68,8 @@ func (m *NetConfigList) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *NetConfigList) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *NetConfigList) validateSummary(formats strfmt.Registry) error {
 		if err := m.Summary.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summary")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *NetConfigList) contextValidateList(ctx context.Context, formats strfmt.
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -158,6 +166,8 @@ func (m *NetConfigList) contextValidateNext(ctx context.Context, formats strfmt.
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *NetConfigList) contextValidateSummary(ctx context.Context, formats strf
 		if err := m.Summary.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summary")
 			}
 			return err
 		}

--- a/swagger_models/net_inst_config.go
+++ b/swagger_models/net_inst_config.go
@@ -227,6 +227,8 @@ func (m *NetInstConfig) validateDNSList(formats strfmt.Registry) error {
 			if err := m.DNSList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("dnsList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("dnsList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -258,6 +260,8 @@ func (m *NetInstConfig) validateIP(formats strfmt.Registry) error {
 		if err := m.IP.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ip")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ip")
 			}
 			return err
 		}
@@ -280,6 +284,8 @@ func (m *NetInstConfig) validateKind(formats strfmt.Registry) error {
 		if err := m.Kind.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kind")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("kind")
 			}
 			return err
 		}
@@ -297,6 +303,8 @@ func (m *NetInstConfig) validateLisp(formats strfmt.Registry) error {
 		if err := m.Lisp.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("lisp")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("lisp")
 			}
 			return err
 		}
@@ -335,6 +343,8 @@ func (m *NetInstConfig) validateOpaque(formats strfmt.Registry) error {
 		if err := m.Opaque.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("opaque")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("opaque")
 			}
 			return err
 		}
@@ -361,6 +371,8 @@ func (m *NetInstConfig) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -399,6 +411,8 @@ func (m *NetInstConfig) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -457,6 +471,8 @@ func (m *NetInstConfig) contextValidateDNSList(ctx context.Context, formats strf
 			if err := m.DNSList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("dnsList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("dnsList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -482,6 +498,8 @@ func (m *NetInstConfig) contextValidateIP(ctx context.Context, formats strfmt.Re
 		if err := m.IP.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ip")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ip")
 			}
 			return err
 		}
@@ -496,6 +514,8 @@ func (m *NetInstConfig) contextValidateKind(ctx context.Context, formats strfmt.
 		if err := m.Kind.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kind")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("kind")
 			}
 			return err
 		}
@@ -510,6 +530,8 @@ func (m *NetInstConfig) contextValidateLisp(ctx context.Context, formats strfmt.
 		if err := m.Lisp.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("lisp")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("lisp")
 			}
 			return err
 		}
@@ -524,6 +546,8 @@ func (m *NetInstConfig) contextValidateOpaque(ctx context.Context, formats strfm
 		if err := m.Opaque.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("opaque")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("opaque")
 			}
 			return err
 		}
@@ -538,6 +562,8 @@ func (m *NetInstConfig) contextValidateRevision(ctx context.Context, formats str
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -552,6 +578,8 @@ func (m *NetInstConfig) contextValidateType(ctx context.Context, formats strfmt.
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/net_inst_list.go
+++ b/swagger_models/net_inst_list.go
@@ -68,6 +68,8 @@ func (m *NetInstList) validateCfgList(formats strfmt.Registry) error {
 			if err := m.CfgList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("cfgList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cfgList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -92,6 +94,8 @@ func (m *NetInstList) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -111,6 +115,8 @@ func (m *NetInstList) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -149,6 +155,8 @@ func (m *NetInstList) contextValidateCfgList(ctx context.Context, formats strfmt
 			if err := m.CfgList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("cfgList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cfgList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -167,6 +175,8 @@ func (m *NetInstList) contextValidateList(ctx context.Context, formats strfmt.Re
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -183,6 +193,8 @@ func (m *NetInstList) contextValidateNext(ctx context.Context, formats strfmt.Re
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}

--- a/swagger_models/net_inst_opaque_config.go
+++ b/swagger_models/net_inst_opaque_config.go
@@ -58,6 +58,8 @@ func (m *NetInstOpaqueConfig) validateLisp(formats strfmt.Registry) error {
 		if err := m.Lisp.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("lisp")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("lisp")
 			}
 			return err
 		}
@@ -75,6 +77,8 @@ func (m *NetInstOpaqueConfig) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -107,6 +111,8 @@ func (m *NetInstOpaqueConfig) contextValidateLisp(ctx context.Context, formats s
 		if err := m.Lisp.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("lisp")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("lisp")
 			}
 			return err
 		}
@@ -121,6 +127,8 @@ func (m *NetInstOpaqueConfig) contextValidateType(ctx context.Context, formats s
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/net_inst_short_config.go
+++ b/swagger_models/net_inst_short_config.go
@@ -104,6 +104,8 @@ func (m *NetInstShortConfig) validateKind(formats strfmt.Registry) error {
 		if err := m.Kind.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kind")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("kind")
 			}
 			return err
 		}
@@ -141,6 +143,8 @@ func (m *NetInstShortConfig) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -186,6 +190,8 @@ func (m *NetInstShortConfig) contextValidateKind(ctx context.Context, formats st
 		if err := m.Kind.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kind")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("kind")
 			}
 			return err
 		}
@@ -200,6 +206,8 @@ func (m *NetInstShortConfig) contextValidateType(ctx context.Context, formats st
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/net_inst_status_filter.go
+++ b/swagger_models/net_inst_status_filter.go
@@ -60,6 +60,8 @@ func (m *NetInstStatusFilter) validateRunState(formats strfmt.Registry) error {
 		if err := m.RunState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -88,6 +90,8 @@ func (m *NetInstStatusFilter) contextValidateRunState(ctx context.Context, forma
 		if err := m.RunState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}

--- a/swagger_models/net_inst_status_list_msg.go
+++ b/swagger_models/net_inst_status_list_msg.go
@@ -61,6 +61,8 @@ func (m *NetInstStatusListMsg) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -80,6 +82,8 @@ func (m *NetInstStatusListMsg) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -114,6 +118,8 @@ func (m *NetInstStatusListMsg) contextValidateList(ctx context.Context, formats 
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -130,6 +136,8 @@ func (m *NetInstStatusListMsg) contextValidateNext(ctx context.Context, formats 
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}

--- a/swagger_models/net_inst_status_msg.go
+++ b/swagger_models/net_inst_status_msg.go
@@ -156,6 +156,8 @@ func (m *NetInstStatusMsg) validateAssignedAdapters(formats strfmt.Registry) err
 			if err := m.AssignedAdapters[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("assignedAdapters" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("assignedAdapters" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -200,6 +202,8 @@ func (m *NetInstStatusMsg) validateErrInfo(formats strfmt.Registry) error {
 			if err := m.ErrInfo[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("errInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("errInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -236,6 +240,8 @@ func (m *NetInstStatusMsg) validateIPMappings(formats strfmt.Registry) error {
 			if err := m.IPMappings[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("ipMappings" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("ipMappings" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -255,6 +261,8 @@ func (m *NetInstStatusMsg) validateKind(formats strfmt.Registry) error {
 		if err := m.Kind.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kind")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("kind")
 			}
 			return err
 		}
@@ -292,6 +300,8 @@ func (m *NetInstStatusMsg) validateRunState(formats strfmt.Registry) error {
 		if err := m.RunState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -326,6 +336,8 @@ func (m *NetInstStatusMsg) validateVifs(formats strfmt.Registry) error {
 			if err := m.Vifs[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("vifs" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("vifs" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -382,6 +394,8 @@ func (m *NetInstStatusMsg) contextValidateAssignedAdapters(ctx context.Context, 
 			if err := m.AssignedAdapters[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("assignedAdapters" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("assignedAdapters" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -400,6 +414,8 @@ func (m *NetInstStatusMsg) contextValidateErrInfo(ctx context.Context, formats s
 			if err := m.ErrInfo[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("errInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("errInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -427,6 +443,8 @@ func (m *NetInstStatusMsg) contextValidateIPMappings(ctx context.Context, format
 			if err := m.IPMappings[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("ipMappings" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("ipMappings" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -443,6 +461,8 @@ func (m *NetInstStatusMsg) contextValidateKind(ctx context.Context, formats strf
 		if err := m.Kind.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kind")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("kind")
 			}
 			return err
 		}
@@ -457,6 +477,8 @@ func (m *NetInstStatusMsg) contextValidateRunState(ctx context.Context, formats 
 		if err := m.RunState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -473,6 +495,8 @@ func (m *NetInstStatusMsg) contextValidateVifs(ctx context.Context, formats strf
 			if err := m.Vifs[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("vifs" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("vifs" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/net_inst_status_summary_msg.go
+++ b/swagger_models/net_inst_status_summary_msg.go
@@ -139,6 +139,8 @@ func (m *NetInstStatusSummaryMsg) validateKind(formats strfmt.Registry) error {
 		if err := m.Kind.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kind")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("kind")
 			}
 			return err
 		}
@@ -176,6 +178,8 @@ func (m *NetInstStatusSummaryMsg) validateRunState(formats strfmt.Registry) erro
 		if err := m.RunState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -233,6 +237,8 @@ func (m *NetInstStatusSummaryMsg) contextValidateKind(ctx context.Context, forma
 		if err := m.Kind.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kind")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("kind")
 			}
 			return err
 		}
@@ -247,6 +253,8 @@ func (m *NetInstStatusSummaryMsg) contextValidateRunState(ctx context.Context, f
 		if err := m.RunState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}

--- a/swagger_models/net_proxy_config.go
+++ b/swagger_models/net_proxy_config.go
@@ -79,6 +79,8 @@ func (m *NetProxyConfig) validateProxies(formats strfmt.Registry) error {
 			if err := m.Proxies[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("proxies" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("proxies" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -111,6 +113,8 @@ func (m *NetProxyConfig) contextValidateProxies(ctx context.Context, formats str
 			if err := m.Proxies[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("proxies" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("proxies" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/net_proxy_server.go
+++ b/swagger_models/net_proxy_server.go
@@ -56,6 +56,8 @@ func (m *NetProxyServer) validateProto(formats strfmt.Registry) error {
 		if err := m.Proto.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("proto")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("proto")
 			}
 			return err
 		}
@@ -84,6 +86,8 @@ func (m *NetProxyServer) contextValidateProto(ctx context.Context, formats strfm
 		if err := m.Proto.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("proto")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("proto")
 			}
 			return err
 		}

--- a/swagger_models/net_proxy_status.go
+++ b/swagger_models/net_proxy_status.go
@@ -79,6 +79,8 @@ func (m *NetProxyStatus) validateProxies(formats strfmt.Registry) error {
 			if err := m.Proxies[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("proxies" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("proxies" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -111,6 +113,8 @@ func (m *NetProxyStatus) contextValidateProxies(ctx context.Context, formats str
 			if err := m.Proxies[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("proxies" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("proxies" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/net_wifi_config.go
+++ b/swagger_models/net_wifi_config.go
@@ -77,6 +77,8 @@ func (m *NetWifiConfig) validateCrypto(formats strfmt.Registry) error {
 		if err := m.Crypto.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("crypto")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("crypto")
 			}
 			return err
 		}
@@ -94,6 +96,8 @@ func (m *NetWifiConfig) validateKeyScheme(formats strfmt.Registry) error {
 		if err := m.KeyScheme.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keyScheme")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("keyScheme")
 			}
 			return err
 		}
@@ -111,6 +115,8 @@ func (m *NetWifiConfig) validateSecret(formats strfmt.Registry) error {
 		if err := m.Secret.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("secret")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("secret")
 			}
 			return err
 		}
@@ -147,6 +153,8 @@ func (m *NetWifiConfig) contextValidateCrypto(ctx context.Context, formats strfm
 		if err := m.Crypto.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("crypto")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("crypto")
 			}
 			return err
 		}
@@ -161,6 +169,8 @@ func (m *NetWifiConfig) contextValidateKeyScheme(ctx context.Context, formats st
 		if err := m.KeyScheme.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keyScheme")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("keyScheme")
 			}
 			return err
 		}
@@ -175,6 +185,8 @@ func (m *NetWifiConfig) contextValidateSecret(ctx context.Context, formats strfm
 		if err := m.Secret.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("secret")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("secret")
 			}
 			return err
 		}

--- a/swagger_models/net_wireless_config.go
+++ b/swagger_models/net_wireless_config.go
@@ -62,6 +62,8 @@ func (m *NetWirelessConfig) validateCellularCfg(formats strfmt.Registry) error {
 		if err := m.CellularCfg.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cellularCfg")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cellularCfg")
 			}
 			return err
 		}
@@ -79,6 +81,8 @@ func (m *NetWirelessConfig) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -96,6 +100,8 @@ func (m *NetWirelessConfig) validateWifiCfg(formats strfmt.Registry) error {
 		if err := m.WifiCfg.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("wifiCfg")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("wifiCfg")
 			}
 			return err
 		}
@@ -132,6 +138,8 @@ func (m *NetWirelessConfig) contextValidateCellularCfg(ctx context.Context, form
 		if err := m.CellularCfg.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cellularCfg")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cellularCfg")
 			}
 			return err
 		}
@@ -146,6 +154,8 @@ func (m *NetWirelessConfig) contextValidateType(ctx context.Context, formats str
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -160,6 +170,8 @@ func (m *NetWirelessConfig) contextValidateWifiCfg(ctx context.Context, formats 
 		if err := m.WifiCfg.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("wifiCfg")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("wifiCfg")
 			}
 			return err
 		}

--- a/swagger_models/network_config_or_default.go
+++ b/swagger_models/network_config_or_default.go
@@ -51,6 +51,8 @@ func (m *NetworkConfigOrDefault) validateNetInstanceConfig(formats strfmt.Regist
 		if err := m.NetInstanceConfig.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("netInstanceConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("netInstanceConfig")
 			}
 			return err
 		}
@@ -79,6 +81,8 @@ func (m *NetworkConfigOrDefault) contextValidateNetInstanceConfig(ctx context.Co
 		if err := m.NetInstanceConfig.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("netInstanceConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("netInstanceConfig")
 			}
 			return err
 		}

--- a/swagger_models/network_d_h_c_p_type.go
+++ b/swagger_models/network_d_h_c_p_type.go
@@ -26,8 +26,12 @@ import (
 type NetworkDHCPType string
 
 func NewNetworkDHCPType(value NetworkDHCPType) *NetworkDHCPType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated NetworkDHCPType.
+func (m NetworkDHCPType) Pointer() *NetworkDHCPType {
+	return &m
 }
 
 const (

--- a/swagger_models/network_instance_dhcp_type.go
+++ b/swagger_models/network_instance_dhcp_type.go
@@ -24,8 +24,12 @@ import (
 type NetworkInstanceDhcpType string
 
 func NewNetworkInstanceDhcpType(value NetworkInstanceDhcpType) *NetworkInstanceDhcpType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated NetworkInstanceDhcpType.
+func (m NetworkInstanceDhcpType) Pointer() *NetworkInstanceDhcpType {
+	return &m
 }
 
 const (

--- a/swagger_models/network_instance_kind.go
+++ b/swagger_models/network_instance_kind.go
@@ -23,8 +23,12 @@ import (
 type NetworkInstanceKind string
 
 func NewNetworkInstanceKind(value NetworkInstanceKind) *NetworkInstanceKind {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated NetworkInstanceKind.
+func (m NetworkInstanceKind) Pointer() *NetworkInstanceKind {
+	return &m
 }
 
 const (

--- a/swagger_models/network_kind.go
+++ b/swagger_models/network_kind.go
@@ -24,8 +24,12 @@ import (
 type NetworkKind string
 
 func NewNetworkKind(value NetworkKind) *NetworkKind {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated NetworkKind.
+func (m NetworkKind) Pointer() *NetworkKind {
+	return &m
 }
 
 const (

--- a/swagger_models/network_policy.go
+++ b/swagger_models/network_policy.go
@@ -59,6 +59,8 @@ func (m *NetworkPolicy) validateNetInstanceConfig(formats strfmt.Registry) error
 			if err := m.NetInstanceConfig[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("netInstanceConfig" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("netInstanceConfig" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -91,6 +93,8 @@ func (m *NetworkPolicy) contextValidateNetInstanceConfig(ctx context.Context, fo
 			if err := m.NetInstanceConfig[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("netInstanceConfig" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("netInstanceConfig" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/network_proxy_proto.go
+++ b/swagger_models/network_proxy_proto.go
@@ -23,8 +23,12 @@ import (
 type NetworkProxyProto string
 
 func NewNetworkProxyProto(value NetworkProxyProto) *NetworkProxyProto {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated NetworkProxyProto.
+func (m NetworkProxyProto) Pointer() *NetworkProxyProto {
+	return &m
 }
 
 const (

--- a/swagger_models/network_status.go
+++ b/swagger_models/network_status.go
@@ -89,6 +89,8 @@ func (m *NetworkStatus) validateDNS(formats strfmt.Registry) error {
 		if err := m.DNS.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dns")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dns")
 			}
 			return err
 		}
@@ -106,6 +108,8 @@ func (m *NetworkStatus) validateErrInfo(formats strfmt.Registry) error {
 		if err := m.ErrInfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("errInfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("errInfo")
 			}
 			return err
 		}
@@ -123,6 +127,8 @@ func (m *NetworkStatus) validateLocation(formats strfmt.Registry) error {
 		if err := m.Location.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("location")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("location")
 			}
 			return err
 		}
@@ -140,6 +146,8 @@ func (m *NetworkStatus) validateProxy(formats strfmt.Registry) error {
 		if err := m.Proxy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("proxy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("proxy")
 			}
 			return err
 		}
@@ -180,6 +188,8 @@ func (m *NetworkStatus) contextValidateDNS(ctx context.Context, formats strfmt.R
 		if err := m.DNS.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dns")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("dns")
 			}
 			return err
 		}
@@ -194,6 +204,8 @@ func (m *NetworkStatus) contextValidateErrInfo(ctx context.Context, formats strf
 		if err := m.ErrInfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("errInfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("errInfo")
 			}
 			return err
 		}
@@ -208,6 +220,8 @@ func (m *NetworkStatus) contextValidateLocation(ctx context.Context, formats str
 		if err := m.Location.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("location")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("location")
 			}
 			return err
 		}
@@ -222,6 +236,8 @@ func (m *NetworkStatus) contextValidateProxy(ctx context.Context, formats strfmt
 		if err := m.Proxy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("proxy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("proxy")
 			}
 			return err
 		}

--- a/swagger_models/network_wi_fi_key_scheme.go
+++ b/swagger_models/network_wi_fi_key_scheme.go
@@ -23,8 +23,12 @@ import (
 type NetworkWiFiKeyScheme string
 
 func NewNetworkWiFiKeyScheme(value NetworkWiFiKeyScheme) *NetworkWiFiKeyScheme {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated NetworkWiFiKeyScheme.
+func (m NetworkWiFiKeyScheme) Pointer() *NetworkWiFiKeyScheme {
+	return &m
 }
 
 const (

--- a/swagger_models/network_wireless_type.go
+++ b/swagger_models/network_wireless_type.go
@@ -23,8 +23,12 @@ import (
 type NetworkWirelessType string
 
 func NewNetworkWirelessType(value NetworkWirelessType) *NetworkWirelessType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated NetworkWirelessType.
+func (m NetworkWirelessType) Pointer() *NetworkWirelessType {
+	return &m
 }
 
 const (

--- a/swagger_models/object_tag_filter.go
+++ b/swagger_models/object_tag_filter.go
@@ -56,6 +56,8 @@ func (m *ObjectTagFilter) validateObjType(formats strfmt.Registry) error {
 		if err := m.ObjType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("objType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("objType")
 			}
 			return err
 		}
@@ -84,6 +86,8 @@ func (m *ObjectTagFilter) contextValidateObjType(ctx context.Context, formats st
 		if err := m.ObjType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("objType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("objType")
 			}
 			return err
 		}

--- a/swagger_models/object_tags_list.go
+++ b/swagger_models/object_tags_list.go
@@ -58,6 +58,8 @@ func (m *ObjectTagsList) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -80,6 +82,8 @@ func (m *ObjectTagsList) validateObjectTags(formats strfmt.Registry) error {
 			if err := m.ObjectTags[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("objectTags" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("objectTags" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -114,6 +118,8 @@ func (m *ObjectTagsList) contextValidateNext(ctx context.Context, formats strfmt
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -130,6 +136,8 @@ func (m *ObjectTagsList) contextValidateObjectTags(ctx context.Context, formats 
 			if err := m.ObjectTags[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("objectTags" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("objectTags" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/object_type.go
+++ b/swagger_models/object_type.go
@@ -23,8 +23,12 @@ import (
 type ObjectType string
 
 func NewObjectType(value ObjectType) *ObjectType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ObjectType.
+func (m ObjectType) Pointer() *ObjectType {
+	return &m
 }
 
 const (

--- a/swagger_models/opaque_config_type.go
+++ b/swagger_models/opaque_config_type.go
@@ -23,8 +23,12 @@ import (
 type OpaqueConfigType string
 
 func NewOpaqueConfigType(value OpaqueConfigType) *OpaqueConfigType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated OpaqueConfigType.
+func (m OpaqueConfigType) Pointer() *OpaqueConfigType {
+	return &m
 }
 
 const (

--- a/swagger_models/origin.go
+++ b/swagger_models/origin.go
@@ -29,8 +29,12 @@ import (
 type Origin string
 
 func NewOrigin(value Origin) *Origin {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated Origin.
+func (m Origin) Pointer() *Origin {
+	return &m
 }
 
 const (

--- a/swagger_models/p_c_r_template.go
+++ b/swagger_models/p_c_r_template.go
@@ -60,6 +60,8 @@ func (m *PCRTemplate) validatePCRValues(formats strfmt.Registry) error {
 			if err := m.PCRValues[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("PCRValues" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("PCRValues" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -92,6 +94,8 @@ func (m *PCRTemplate) contextValidatePCRValues(ctx context.Context, formats strf
 			if err := m.PCRValues[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("PCRValues" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("PCRValues" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/p_c_r_type.go
+++ b/swagger_models/p_c_r_type.go
@@ -25,8 +25,12 @@ import (
 type PCRType string
 
 func NewPCRType(value PCRType) *PCRType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated PCRType.
+func (m PCRType) Pointer() *PCRType {
+	return &m
 }
 
 const (

--- a/swagger_models/p_c_r_value.go
+++ b/swagger_models/p_c_r_value.go
@@ -54,6 +54,8 @@ func (m *PCRValue) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -82,6 +84,8 @@ func (m *PCRValue) contextValidateType(ctx context.Context, formats strfmt.Regis
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/phy_adapter.go
+++ b/swagger_models/phy_adapter.go
@@ -56,6 +56,8 @@ func (m *PhyAdapter) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -84,6 +86,8 @@ func (m *PhyAdapter) contextValidateType(ctx context.Context, formats strfmt.Reg
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/policies.go
+++ b/swagger_models/policies.go
@@ -68,6 +68,8 @@ func (m *Policies) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *Policies) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *Policies) validateSummaryByState(formats strfmt.Registry) error {
 		if err := m.SummaryByState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *Policies) contextValidateList(ctx context.Context, formats strfmt.Regis
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -158,6 +166,8 @@ func (m *Policies) contextValidateNext(ctx context.Context, formats strfmt.Regis
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *Policies) contextValidateSummaryByState(ctx context.Context, formats st
 		if err := m.SummaryByState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}

--- a/swagger_models/policy.go
+++ b/swagger_models/policy.go
@@ -67,6 +67,8 @@ func (m *Policy) validateAccess(formats strfmt.Registry) error {
 		if err := m.Access.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("access")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("access")
 			}
 			return err
 		}
@@ -84,6 +86,8 @@ func (m *Policy) validateScope(formats strfmt.Registry) error {
 		if err := m.Scope.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("scope")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("scope")
 			}
 			return err
 		}
@@ -116,6 +120,8 @@ func (m *Policy) contextValidateAccess(ctx context.Context, formats strfmt.Regis
 		if err := m.Access.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("access")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("access")
 			}
 			return err
 		}
@@ -130,6 +136,8 @@ func (m *Policy) contextValidateScope(ctx context.Context, formats strfmt.Regist
 		if err := m.Scope.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("scope")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("scope")
 			}
 			return err
 		}

--- a/swagger_models/policy_access.go
+++ b/swagger_models/policy_access.go
@@ -23,8 +23,12 @@ import (
 type PolicyAccess string
 
 func NewPolicyAccess(value PolicyAccess) *PolicyAccess {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated PolicyAccess.
+func (m PolicyAccess) Pointer() *PolicyAccess {
+	return &m
 }
 
 const (

--- a/swagger_models/policy_config.go
+++ b/swagger_models/policy_config.go
@@ -160,6 +160,8 @@ func (m *PolicyConfig) validateAppPolicy(formats strfmt.Registry) error {
 		if err := m.AppPolicy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appPolicy")
 			}
 			return err
 		}
@@ -177,6 +179,8 @@ func (m *PolicyConfig) validateAttestationPolicy(formats strfmt.Registry) error 
 		if err := m.AttestationPolicy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("attestationPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("attestationPolicy")
 			}
 			return err
 		}
@@ -194,6 +198,8 @@ func (m *PolicyConfig) validateAzurePolicy(formats strfmt.Registry) error {
 		if err := m.AzurePolicy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("azurePolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("azurePolicy")
 			}
 			return err
 		}
@@ -211,6 +217,8 @@ func (m *PolicyConfig) validateClusterPolicy(formats strfmt.Registry) error {
 		if err := m.ClusterPolicy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("clusterPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("clusterPolicy")
 			}
 			return err
 		}
@@ -252,6 +260,8 @@ func (m *PolicyConfig) validateModulePolicy(formats strfmt.Registry) error {
 		if err := m.ModulePolicy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("modulePolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("modulePolicy")
 			}
 			return err
 		}
@@ -290,6 +300,8 @@ func (m *PolicyConfig) validateNetworkPolicy(formats strfmt.Registry) error {
 		if err := m.NetworkPolicy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("networkPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("networkPolicy")
 			}
 			return err
 		}
@@ -307,6 +319,8 @@ func (m *PolicyConfig) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -324,6 +338,8 @@ func (m *PolicyConfig) validateStatus(formats strfmt.Registry) error {
 		if err := m.Status.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}
@@ -379,6 +395,8 @@ func (m *PolicyConfig) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -443,6 +461,8 @@ func (m *PolicyConfig) contextValidateAppPolicy(ctx context.Context, formats str
 		if err := m.AppPolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appPolicy")
 			}
 			return err
 		}
@@ -457,6 +477,8 @@ func (m *PolicyConfig) contextValidateAttestationPolicy(ctx context.Context, for
 		if err := m.AttestationPolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("attestationPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("attestationPolicy")
 			}
 			return err
 		}
@@ -471,6 +493,8 @@ func (m *PolicyConfig) contextValidateAzurePolicy(ctx context.Context, formats s
 		if err := m.AzurePolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("azurePolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("azurePolicy")
 			}
 			return err
 		}
@@ -485,6 +509,8 @@ func (m *PolicyConfig) contextValidateClusterPolicy(ctx context.Context, formats
 		if err := m.ClusterPolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("clusterPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("clusterPolicy")
 			}
 			return err
 		}
@@ -508,6 +534,8 @@ func (m *PolicyConfig) contextValidateModulePolicy(ctx context.Context, formats 
 		if err := m.ModulePolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("modulePolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("modulePolicy")
 			}
 			return err
 		}
@@ -522,6 +550,8 @@ func (m *PolicyConfig) contextValidateNetworkPolicy(ctx context.Context, formats
 		if err := m.NetworkPolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("networkPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("networkPolicy")
 			}
 			return err
 		}
@@ -536,6 +566,8 @@ func (m *PolicyConfig) contextValidateRevision(ctx context.Context, formats strf
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -550,6 +582,8 @@ func (m *PolicyConfig) contextValidateStatus(ctx context.Context, formats strfmt
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}
@@ -564,6 +598,8 @@ func (m *PolicyConfig) contextValidateType(ctx context.Context, formats strfmt.R
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/policy_doc_version.go
+++ b/swagger_models/policy_doc_version.go
@@ -57,6 +57,8 @@ func (m *PolicyDocVersion) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -85,6 +87,8 @@ func (m *PolicyDocVersion) contextValidateRevision(ctx context.Context, formats 
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}

--- a/swagger_models/policy_doc_version_list.go
+++ b/swagger_models/policy_doc_version_list.go
@@ -68,6 +68,8 @@ func (m *PolicyDocVersionList) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *PolicyDocVersionList) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *PolicyDocVersionList) validateSummary(formats strfmt.Registry) error {
 		if err := m.Summary.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summary")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *PolicyDocVersionList) contextValidateList(ctx context.Context, formats 
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -158,6 +166,8 @@ func (m *PolicyDocVersionList) contextValidateNext(ctx context.Context, formats 
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *PolicyDocVersionList) contextValidateSummary(ctx context.Context, forma
 		if err := m.Summary.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summary")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summary")
 			}
 			return err
 		}

--- a/swagger_models/policy_doc_version_resp.go
+++ b/swagger_models/policy_doc_version_resp.go
@@ -62,6 +62,8 @@ func (m *PolicyDocVersionResp) validatePinfo(formats strfmt.Registry) error {
 		if err := m.Pinfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("pinfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("pinfo")
 			}
 			return err
 		}
@@ -79,6 +81,8 @@ func (m *PolicyDocVersionResp) validatePlist(formats strfmt.Registry) error {
 		if err := m.Plist.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("plist")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("plist")
 			}
 			return err
 		}
@@ -96,6 +100,8 @@ func (m *PolicyDocVersionResp) validateResult(formats strfmt.Registry) error {
 		if err := m.Result.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("result")
 			}
 			return err
 		}
@@ -132,6 +138,8 @@ func (m *PolicyDocVersionResp) contextValidatePinfo(ctx context.Context, formats
 		if err := m.Pinfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("pinfo")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("pinfo")
 			}
 			return err
 		}
@@ -146,6 +154,8 @@ func (m *PolicyDocVersionResp) contextValidatePlist(ctx context.Context, formats
 		if err := m.Plist.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("plist")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("plist")
 			}
 			return err
 		}
@@ -160,6 +170,8 @@ func (m *PolicyDocVersionResp) contextValidateResult(ctx context.Context, format
 		if err := m.Result.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("result")
 			}
 			return err
 		}

--- a/swagger_models/policy_scope.go
+++ b/swagger_models/policy_scope.go
@@ -23,8 +23,12 @@ import (
 type PolicyScope string
 
 func NewPolicyScope(value PolicyScope) *PolicyScope {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated PolicyScope.
+func (m PolicyScope) Pointer() *PolicyScope {
+	return &m
 }
 
 const (

--- a/swagger_models/policy_status.go
+++ b/swagger_models/policy_status.go
@@ -23,8 +23,12 @@ import (
 type PolicyStatus string
 
 func NewPolicyStatus(value PolicyStatus) *PolicyStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated PolicyStatus.
+func (m PolicyStatus) Pointer() *PolicyStatus {
+	return &m
 }
 
 const (

--- a/swagger_models/policy_type.go
+++ b/swagger_models/policy_type.go
@@ -23,8 +23,12 @@ import (
 type PolicyType string
 
 func NewPolicyType(value PolicyType) *PolicyType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated PolicyType.
+func (m PolicyType) Pointer() *PolicyType {
+	return &m
 }
 
 const (

--- a/swagger_models/policy_version_list.go
+++ b/swagger_models/policy_version_list.go
@@ -54,6 +54,8 @@ func (m *PolicyVersionList) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -86,6 +88,8 @@ func (m *PolicyVersionList) contextValidateList(ctx context.Context, formats str
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/protobuf_null_value.go
+++ b/swagger_models/protobuf_null_value.go
@@ -28,8 +28,12 @@ import (
 type ProtobufNullValue string
 
 func NewProtobufNullValue(value ProtobufNullValue) *ProtobufNullValue {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ProtobufNullValue.
+func (m ProtobufNullValue) Pointer() *ProtobufNullValue {
+	return &m
 }
 
 const (

--- a/swagger_models/realm.go
+++ b/swagger_models/realm.go
@@ -158,6 +158,8 @@ func (m *Realm) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -220,6 +222,8 @@ func (m *Realm) contextValidateRevision(ctx context.Context, formats strfmt.Regi
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}

--- a/swagger_models/realms.go
+++ b/swagger_models/realms.go
@@ -68,6 +68,8 @@ func (m *Realms) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *Realms) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *Realms) validateSummaryByState(formats strfmt.Registry) error {
 		if err := m.SummaryByState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *Realms) contextValidateList(ctx context.Context, formats strfmt.Registr
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -158,6 +166,8 @@ func (m *Realms) contextValidateNext(ctx context.Context, formats strfmt.Registr
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *Realms) contextValidateSummaryByState(ctx context.Context, formats strf
 		if err := m.SummaryByState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}

--- a/swagger_models/role.go
+++ b/swagger_models/role.go
@@ -160,6 +160,8 @@ func (m *Role) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -183,6 +185,8 @@ func (m *Role) validateScopes(formats strfmt.Registry) error {
 			if err := m.Scopes[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("scopes" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("scopes" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -202,6 +206,8 @@ func (m *Role) validateState(formats strfmt.Registry) error {
 		if err := m.State.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("state")
 			}
 			return err
 		}
@@ -245,6 +251,8 @@ func (m *Role) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -298,6 +306,8 @@ func (m *Role) contextValidateRevision(ctx context.Context, formats strfmt.Regis
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -314,6 +324,8 @@ func (m *Role) contextValidateScopes(ctx context.Context, formats strfmt.Registr
 			if err := m.Scopes[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("scopes" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("scopes" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -330,6 +342,8 @@ func (m *Role) contextValidateState(ctx context.Context, formats strfmt.Registry
 		if err := m.State.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("state")
 			}
 			return err
 		}
@@ -344,6 +358,8 @@ func (m *Role) contextValidateType(ctx context.Context, formats strfmt.Registry)
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/role_state.go
+++ b/swagger_models/role_state.go
@@ -24,8 +24,12 @@ import (
 type RoleState string
 
 func NewRoleState(value RoleState) *RoleState {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated RoleState.
+func (m RoleState) Pointer() *RoleState {
+	return &m
 }
 
 const (

--- a/swagger_models/roles.go
+++ b/swagger_models/roles.go
@@ -68,6 +68,8 @@ func (m *Roles) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *Roles) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *Roles) validateSummaryByState(formats strfmt.Registry) error {
 		if err := m.SummaryByState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *Roles) contextValidateList(ctx context.Context, formats strfmt.Registry
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -158,6 +166,8 @@ func (m *Roles) contextValidateNext(ctx context.Context, formats strfmt.Registry
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *Roles) contextValidateSummaryByState(ctx context.Context, formats strfm
 		if err := m.SummaryByState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}

--- a/swagger_models/run_state.go
+++ b/swagger_models/run_state.go
@@ -43,8 +43,12 @@ import (
 type RunState string
 
 func NewRunState(value RunState) *RunState {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated RunState.
+func (m RunState) Pointer() *RunState {
+	return &m
 }
 
 const (

--- a/swagger_models/runtime_stream_error.go
+++ b/swagger_models/runtime_stream_error.go
@@ -66,6 +66,8 @@ func (m *RuntimeStreamError) validateDetails(formats strfmt.Registry) error {
 			if err := m.Details[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("details" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("details" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -98,6 +100,8 @@ func (m *RuntimeStreamError) contextValidateDetails(ctx context.Context, formats
 			if err := m.Details[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("details" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("details" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/s_w_info.go
+++ b/swagger_models/s_w_info.go
@@ -65,6 +65,8 @@ func (m *SWInfo) validateState(formats strfmt.Registry) error {
 		if err := m.State.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("state")
 			}
 			return err
 		}
@@ -93,6 +95,8 @@ func (m *SWInfo) contextValidateState(ctx context.Context, formats strfmt.Regist
 		if err := m.State.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("state")
 			}
 			return err
 		}

--- a/swagger_models/s_w_state.go
+++ b/swagger_models/s_w_state.go
@@ -34,8 +34,12 @@ import (
 type SWState string
 
 func NewSWState(value SWState) *SWState {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated SWState.
+func (m SWState) Pointer() *SWState {
+	return &m
 }
 
 const (

--- a/swagger_models/service_point.go
+++ b/swagger_models/service_point.go
@@ -56,6 +56,8 @@ func (m *ServicePoint) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -84,6 +86,8 @@ func (m *ServicePoint) contextValidateType(ctx context.Context, formats strfmt.R
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/severity.go
+++ b/swagger_models/severity.go
@@ -23,8 +23,12 @@ import (
 type Severity string
 
 func NewSeverity(value Severity) *Severity {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated Severity.
+func (m Severity) Pointer() *Severity {
+	return &m
 }
 
 const (

--- a/swagger_models/simcard_state.go
+++ b/swagger_models/simcard_state.go
@@ -23,8 +23,12 @@ import (
 type SimcardState string
 
 func NewSimcardState(value SimcardState) *SimcardState {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated SimcardState.
+func (m SimcardState) Pointer() *SimcardState {
+	return &m
 }
 
 const (

--- a/swagger_models/simple_user.go
+++ b/swagger_models/simple_user.go
@@ -60,6 +60,8 @@ func (m *SimpleUser) validateState(formats strfmt.Registry) error {
 		if err := m.State.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("state")
 			}
 			return err
 		}
@@ -88,6 +90,8 @@ func (m *SimpleUser) contextValidateState(ctx context.Context, formats strfmt.Re
 		if err := m.State.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("state")
 			}
 			return err
 		}

--- a/swagger_models/sp_type.go
+++ b/swagger_models/sp_type.go
@@ -27,8 +27,12 @@ import (
 type SpType string
 
 func NewSpType(value SpType) *SpType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated SpType.
+func (m SpType) Pointer() *SpType {
+	return &m
 }
 
 const (

--- a/swagger_models/status.go
+++ b/swagger_models/status.go
@@ -59,6 +59,8 @@ func (m *Status) validateCode(formats strfmt.Registry) error {
 		if err := m.Code.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("code")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("code")
 			}
 			return err
 		}
@@ -76,6 +78,8 @@ func (m *Status) validateDescription(formats strfmt.Registry) error {
 		if err := m.Description.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("description")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("description")
 			}
 			return err
 		}
@@ -108,6 +112,8 @@ func (m *Status) contextValidateCode(ctx context.Context, formats strfmt.Registr
 		if err := m.Code.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("code")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("code")
 			}
 			return err
 		}
@@ -122,6 +128,8 @@ func (m *Status) contextValidateDescription(ctx context.Context, formats strfmt.
 		if err := m.Description.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("description")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("description")
 			}
 			return err
 		}

--- a/swagger_models/status_code.go
+++ b/swagger_models/status_code.go
@@ -23,8 +23,12 @@ import (
 type StatusCode string
 
 func NewStatusCode(value StatusCode) *StatusCode {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated StatusCode.
+func (m StatusCode) Pointer() *StatusCode {
+	return &m
 }
 
 const (

--- a/swagger_models/symmetric_key_enrollment_detail.go
+++ b/swagger_models/symmetric_key_enrollment_detail.go
@@ -62,6 +62,8 @@ func (m *SymmetricKeyEnrollmentDetail) validateGroupSymmetricKeyEnrollment(forma
 		if err := m.GroupSymmetricKeyEnrollment.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("groupSymmetricKeyEnrollment")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("groupSymmetricKeyEnrollment")
 			}
 			return err
 		}
@@ -79,6 +81,8 @@ func (m *SymmetricKeyEnrollmentDetail) validateIndividualSymmetricKeyEnrollment(
 		if err := m.IndividualSymmetricKeyEnrollment.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("individualSymmetricKeyEnrollment")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("individualSymmetricKeyEnrollment")
 			}
 			return err
 		}
@@ -96,6 +100,8 @@ func (m *SymmetricKeyEnrollmentDetail) validateType(formats strfmt.Registry) err
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -132,6 +138,8 @@ func (m *SymmetricKeyEnrollmentDetail) contextValidateGroupSymmetricKeyEnrollmen
 		if err := m.GroupSymmetricKeyEnrollment.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("groupSymmetricKeyEnrollment")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("groupSymmetricKeyEnrollment")
 			}
 			return err
 		}
@@ -146,6 +154,8 @@ func (m *SymmetricKeyEnrollmentDetail) contextValidateIndividualSymmetricKeyEnro
 		if err := m.IndividualSymmetricKeyEnrollment.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("individualSymmetricKeyEnrollment")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("individualSymmetricKeyEnrollment")
 			}
 			return err
 		}
@@ -160,6 +170,8 @@ func (m *SymmetricKeyEnrollmentDetail) contextValidateType(ctx context.Context, 
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/sys_brand.go
+++ b/swagger_models/sys_brand.go
@@ -160,6 +160,8 @@ func (m *SysBrand) validateOriginType(formats strfmt.Registry) error {
 		if err := m.OriginType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -177,6 +179,8 @@ func (m *SysBrand) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -194,6 +198,8 @@ func (m *SysBrand) validateState(formats strfmt.Registry) error {
 		if err := m.State.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("state")
 			}
 			return err
 		}
@@ -256,6 +262,8 @@ func (m *SysBrand) contextValidateOriginType(ctx context.Context, formats strfmt
 		if err := m.OriginType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -270,6 +278,8 @@ func (m *SysBrand) contextValidateRevision(ctx context.Context, formats strfmt.R
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -284,6 +294,8 @@ func (m *SysBrand) contextValidateState(ctx context.Context, formats strfmt.Regi
 		if err := m.State.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("state")
 			}
 			return err
 		}

--- a/swagger_models/sys_brand_filter.go
+++ b/swagger_models/sys_brand_filter.go
@@ -79,6 +79,8 @@ func (m *SysBrandFilter) validateOriginType(formats strfmt.Registry) error {
 		if err := m.OriginType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -107,6 +109,8 @@ func (m *SysBrandFilter) contextValidateOriginType(ctx context.Context, formats 
 		if err := m.OriginType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}

--- a/swagger_models/sys_brands.go
+++ b/swagger_models/sys_brands.go
@@ -70,6 +70,8 @@ func (m *SysBrands) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -89,6 +91,8 @@ func (m *SysBrands) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -106,6 +110,8 @@ func (m *SysBrands) validateTerse(formats strfmt.Registry) error {
 		if err := m.Terse.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("terse")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("terse")
 			}
 			return err
 		}
@@ -144,6 +150,8 @@ func (m *SysBrands) contextValidateList(ctx context.Context, formats strfmt.Regi
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -160,6 +168,8 @@ func (m *SysBrands) contextValidateNext(ctx context.Context, formats strfmt.Regi
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -174,6 +184,8 @@ func (m *SysBrands) contextValidateTerse(ctx context.Context, formats strfmt.Reg
 		if err := m.Terse.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("terse")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("terse")
 			}
 			return err
 		}

--- a/swagger_models/sys_interface.go
+++ b/swagger_models/sys_interface.go
@@ -86,6 +86,8 @@ func (m *SysInterface) validateIntfUsage(formats strfmt.Registry) error {
 		if err := m.IntfUsage.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("intfUsage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("intfUsage")
 			}
 			return err
 		}
@@ -114,6 +116,8 @@ func (m *SysInterface) contextValidateIntfUsage(ctx context.Context, formats str
 		if err := m.IntfUsage.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("intfUsage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("intfUsage")
 			}
 			return err
 		}

--- a/swagger_models/sys_model.go
+++ b/swagger_models/sys_model.go
@@ -167,6 +167,8 @@ func (m *SysModel) validatePCRTemplates(formats strfmt.Registry) error {
 			if err := m.PCRTemplates[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("PCRTemplates" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("PCRTemplates" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -237,6 +239,8 @@ func (m *SysModel) validateIoMemberList(formats strfmt.Registry) error {
 			if err := m.IoMemberList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("ioMemberList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("ioMemberList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -277,6 +281,8 @@ func (m *SysModel) validateOriginType(formats strfmt.Registry) error {
 		if err := m.OriginType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -294,6 +300,8 @@ func (m *SysModel) validateParentDetail(formats strfmt.Registry) error {
 		if err := m.ParentDetail.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("parentDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("parentDetail")
 			}
 			return err
 		}
@@ -311,6 +319,8 @@ func (m *SysModel) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -333,6 +343,8 @@ func (m *SysModel) validateState(formats strfmt.Registry) error {
 		if err := m.State.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("state")
 			}
 			return err
 		}
@@ -376,6 +388,8 @@ func (m *SysModel) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -434,6 +448,8 @@ func (m *SysModel) contextValidatePCRTemplates(ctx context.Context, formats strf
 			if err := m.PCRTemplates[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("PCRTemplates" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("PCRTemplates" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -461,6 +477,8 @@ func (m *SysModel) contextValidateIoMemberList(ctx context.Context, formats strf
 			if err := m.IoMemberList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("ioMemberList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("ioMemberList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -477,6 +495,8 @@ func (m *SysModel) contextValidateOriginType(ctx context.Context, formats strfmt
 		if err := m.OriginType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -491,6 +511,8 @@ func (m *SysModel) contextValidateParentDetail(ctx context.Context, formats strf
 		if err := m.ParentDetail.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("parentDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("parentDetail")
 			}
 			return err
 		}
@@ -505,6 +527,8 @@ func (m *SysModel) contextValidateRevision(ctx context.Context, formats strfmt.R
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -519,6 +543,8 @@ func (m *SysModel) contextValidateState(ctx context.Context, formats strfmt.Regi
 		if err := m.State.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("state")
 			}
 			return err
 		}
@@ -533,6 +559,8 @@ func (m *SysModel) contextValidateType(ctx context.Context, formats strfmt.Regis
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/sys_model_detail.go
+++ b/swagger_models/sys_model_detail.go
@@ -54,6 +54,8 @@ func (m *SysModelDetail) validateCustomModelFields(formats strfmt.Registry) erro
 		if err := m.CustomModelFields.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("customModelFields")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("customModelFields")
 			}
 			return err
 		}
@@ -82,6 +84,8 @@ func (m *SysModelDetail) contextValidateCustomModelFields(ctx context.Context, f
 		if err := m.CustomModelFields.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("customModelFields")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("customModelFields")
 			}
 			return err
 		}

--- a/swagger_models/sys_model_filter.go
+++ b/swagger_models/sys_model_filter.go
@@ -99,6 +99,8 @@ func (m *SysModelFilter) validateOriginType(formats strfmt.Registry) error {
 		if err := m.OriginType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}
@@ -127,6 +129,8 @@ func (m *SysModelFilter) contextValidateOriginType(ctx context.Context, formats 
 		if err := m.OriginType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("originType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("originType")
 			}
 			return err
 		}

--- a/swagger_models/sys_model_state.go
+++ b/swagger_models/sys_model_state.go
@@ -27,8 +27,12 @@ import (
 type SysModelState string
 
 func NewSysModelState(value SysModelState) *SysModelState {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated SysModelState.
+func (m SysModelState) Pointer() *SysModelState {
+	return &m
 }
 
 const (

--- a/swagger_models/sys_models.go
+++ b/swagger_models/sys_models.go
@@ -70,6 +70,8 @@ func (m *SysModels) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -89,6 +91,8 @@ func (m *SysModels) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -106,6 +110,8 @@ func (m *SysModels) validateTerse(formats strfmt.Registry) error {
 		if err := m.Terse.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("terse")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("terse")
 			}
 			return err
 		}
@@ -144,6 +150,8 @@ func (m *SysModels) contextValidateList(ctx context.Context, formats strfmt.Regi
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -160,6 +168,8 @@ func (m *SysModels) contextValidateNext(ctx context.Context, formats strfmt.Regi
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -174,6 +184,8 @@ func (m *SysModels) contextValidateTerse(ctx context.Context, formats strfmt.Reg
 		if err := m.Terse.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("terse")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("terse")
 			}
 			return err
 		}

--- a/swagger_models/t_p_m_enrollment_detail.go
+++ b/swagger_models/t_p_m_enrollment_detail.go
@@ -48,6 +48,8 @@ func (m *TPMEnrollmentDetail) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -76,6 +78,8 @@ func (m *TPMEnrollmentDetail) contextValidateType(ctx context.Context, formats s
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/tag.go
+++ b/swagger_models/tag.go
@@ -146,6 +146,8 @@ func (m *Tag) validateAppPolicy(formats strfmt.Registry) error {
 		if err := m.AppPolicy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appPolicy")
 			}
 			return err
 		}
@@ -163,6 +165,8 @@ func (m *Tag) validateAttestationPolicy(formats strfmt.Registry) error {
 		if err := m.AttestationPolicy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("attestationPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("attestationPolicy")
 			}
 			return err
 		}
@@ -180,6 +184,8 @@ func (m *Tag) validateCloudPolicy(formats strfmt.Registry) error {
 		if err := m.CloudPolicy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cloudPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cloudPolicy")
 			}
 			return err
 		}
@@ -226,6 +232,8 @@ func (m *Tag) validateModulePolicy(formats strfmt.Registry) error {
 			if err := m.ModulePolicy[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("modulePolicy" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("modulePolicy" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -266,6 +274,8 @@ func (m *Tag) validateNetworkPolicy(formats strfmt.Registry) error {
 		if err := m.NetworkPolicy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("networkPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("networkPolicy")
 			}
 			return err
 		}
@@ -283,6 +293,8 @@ func (m *Tag) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -326,6 +338,8 @@ func (m *Tag) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -386,6 +400,8 @@ func (m *Tag) contextValidateAppPolicy(ctx context.Context, formats strfmt.Regis
 		if err := m.AppPolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appPolicy")
 			}
 			return err
 		}
@@ -400,6 +416,8 @@ func (m *Tag) contextValidateAttestationPolicy(ctx context.Context, formats strf
 		if err := m.AttestationPolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("attestationPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("attestationPolicy")
 			}
 			return err
 		}
@@ -414,6 +432,8 @@ func (m *Tag) contextValidateCloudPolicy(ctx context.Context, formats strfmt.Reg
 		if err := m.CloudPolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cloudPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cloudPolicy")
 			}
 			return err
 		}
@@ -443,6 +463,8 @@ func (m *Tag) contextValidateModulePolicy(ctx context.Context, formats strfmt.Re
 			if err := m.ModulePolicy[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("modulePolicy" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("modulePolicy" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -459,6 +481,8 @@ func (m *Tag) contextValidateNetworkPolicy(ctx context.Context, formats strfmt.R
 		if err := m.NetworkPolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("networkPolicy")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("networkPolicy")
 			}
 			return err
 		}
@@ -482,6 +506,8 @@ func (m *Tag) contextValidateRevision(ctx context.Context, formats strfmt.Regist
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -496,6 +522,8 @@ func (m *Tag) contextValidateType(ctx context.Context, formats strfmt.Registry) 
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/tag_filter.go
+++ b/swagger_models/tag_filter.go
@@ -79,6 +79,8 @@ func (m *TagFilter) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -107,6 +109,8 @@ func (m *TagFilter) contextValidateType(ctx context.Context, formats strfmt.Regi
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/tag_status.go
+++ b/swagger_models/tag_status.go
@@ -28,8 +28,12 @@ import (
 type TagStatus string
 
 func NewTagStatus(value TagStatus) *TagStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated TagStatus.
+func (m TagStatus) Pointer() *TagStatus {
+	return &m
 }
 
 const (

--- a/swagger_models/tag_status_filter.go
+++ b/swagger_models/tag_status_filter.go
@@ -79,6 +79,8 @@ func (m *TagStatusFilter) validateStatus(formats strfmt.Registry) error {
 		if err := m.Status.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}
@@ -107,6 +109,8 @@ func (m *TagStatusFilter) contextValidateStatus(ctx context.Context, formats str
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}

--- a/swagger_models/tag_status_list_msg.go
+++ b/swagger_models/tag_status_list_msg.go
@@ -68,6 +68,8 @@ func (m *TagStatusListMsg) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *TagStatusListMsg) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *TagStatusListMsg) validateSummaryByState(formats strfmt.Registry) error
 		if err := m.SummaryByState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *TagStatusListMsg) contextValidateList(ctx context.Context, formats strf
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -158,6 +166,8 @@ func (m *TagStatusListMsg) contextValidateNext(ctx context.Context, formats strf
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *TagStatusListMsg) contextValidateSummaryByState(ctx context.Context, fo
 		if err := m.SummaryByState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}

--- a/swagger_models/tag_status_msg.go
+++ b/swagger_models/tag_status_msg.go
@@ -104,6 +104,8 @@ func (m *TagStatusMsg) validateStatus(formats strfmt.Registry) error {
 		if err := m.Status.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}
@@ -145,6 +147,8 @@ func (m *TagStatusMsg) contextValidateStatus(ctx context.Context, formats strfmt
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}

--- a/swagger_models/tag_type.go
+++ b/swagger_models/tag_type.go
@@ -27,8 +27,12 @@ import (
 type TagType string
 
 func NewTagType(value TagType) *TagType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated TagType.
+func (m TagType) Pointer() *TagType {
+	return &m
 }
 
 const (

--- a/swagger_models/tags.go
+++ b/swagger_models/tags.go
@@ -68,6 +68,8 @@ func (m *Tags) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -87,6 +89,8 @@ func (m *Tags) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -104,6 +108,8 @@ func (m *Tags) validateSummaryByState(formats strfmt.Registry) error {
 		if err := m.SummaryByState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -142,6 +148,8 @@ func (m *Tags) contextValidateList(ctx context.Context, formats strfmt.Registry)
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -158,6 +166,8 @@ func (m *Tags) contextValidateNext(ctx context.Context, formats strfmt.Registry)
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -172,6 +182,8 @@ func (m *Tags) contextValidateSummaryByState(ctx context.Context, formats strfmt
 		if err := m.SummaryByState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}

--- a/swagger_models/top_talkers_response.go
+++ b/swagger_models/top_talkers_response.go
@@ -61,6 +61,8 @@ func (m *TopTalkersResponse) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -80,6 +82,8 @@ func (m *TopTalkersResponse) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -114,6 +118,8 @@ func (m *TopTalkersResponse) contextValidateList(ctx context.Context, formats st
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -130,6 +136,8 @@ func (m *TopTalkersResponse) contextValidateNext(ctx context.Context, formats st
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}

--- a/swagger_models/trans_cause.go
+++ b/swagger_models/trans_cause.go
@@ -23,8 +23,12 @@ import (
 type TransCause string
 
 func NewTransCause(value TransCause) *TransCause {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated TransCause.
+func (m TransCause) Pointer() *TransCause {
+	return &m
 }
 
 const (

--- a/swagger_models/trans_details.go
+++ b/swagger_models/trans_details.go
@@ -58,6 +58,8 @@ func (m *TransDetails) validateCause(formats strfmt.Registry) error {
 		if err := m.Cause.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -75,6 +77,8 @@ func (m *TransDetails) validateScope(formats strfmt.Registry) error {
 		if err := m.Scope.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("scope")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("scope")
 			}
 			return err
 		}
@@ -107,6 +111,8 @@ func (m *TransDetails) contextValidateCause(ctx context.Context, formats strfmt.
 		if err := m.Cause.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cause")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cause")
 			}
 			return err
 		}
@@ -121,6 +127,8 @@ func (m *TransDetails) contextValidateScope(ctx context.Context, formats strfmt.
 		if err := m.Scope.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("scope")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("scope")
 			}
 			return err
 		}

--- a/swagger_models/user_data_template.go
+++ b/swagger_models/user_data_template.go
@@ -48,6 +48,8 @@ func (m *UserDataTemplate) validateCustomConfig(formats strfmt.Registry) error {
 		if err := m.CustomConfig.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("customConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("customConfig")
 			}
 			return err
 		}
@@ -76,6 +78,8 @@ func (m *UserDataTemplate) contextValidateCustomConfig(ctx context.Context, form
 		if err := m.CustomConfig.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("customConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("customConfig")
 			}
 			return err
 		}

--- a/swagger_models/user_role.go
+++ b/swagger_models/user_role.go
@@ -23,8 +23,12 @@ import (
 type UserRole string
 
 func NewUserRole(value UserRole) *UserRole {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated UserRole.
+func (m UserRole) Pointer() *UserRole {
+	return &m
 }
 
 const (

--- a/swagger_models/user_state.go
+++ b/swagger_models/user_state.go
@@ -23,8 +23,12 @@ import (
 type UserState string
 
 func NewUserState(value UserState) *UserState {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated UserState.
+func (m UserState) Pointer() *UserState {
+	return &m
 }
 
 const (

--- a/swagger_models/variable_file_encoding.go
+++ b/swagger_models/variable_file_encoding.go
@@ -26,8 +26,12 @@ import (
 type VariableFileEncoding string
 
 func NewVariableFileEncoding(value VariableFileEncoding) *VariableFileEncoding {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated VariableFileEncoding.
+func (m VariableFileEncoding) Pointer() *VariableFileEncoding {
+	return &m
 }
 
 const (

--- a/swagger_models/variable_group_condition.go
+++ b/swagger_models/variable_group_condition.go
@@ -54,6 +54,8 @@ func (m *VariableGroupCondition) validateOperator(formats strfmt.Registry) error
 		if err := m.Operator.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("operator")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("operator")
 			}
 			return err
 		}
@@ -82,6 +84,8 @@ func (m *VariableGroupCondition) contextValidateOperator(ctx context.Context, fo
 		if err := m.Operator.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("operator")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("operator")
 			}
 			return err
 		}

--- a/swagger_models/variable_group_condition_operator.go
+++ b/swagger_models/variable_group_condition_operator.go
@@ -23,8 +23,12 @@ import (
 type VariableGroupConditionOperator string
 
 func NewVariableGroupConditionOperator(value VariableGroupConditionOperator) *VariableGroupConditionOperator {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated VariableGroupConditionOperator.
+func (m VariableGroupConditionOperator) Pointer() *VariableGroupConditionOperator {
+	return &m
 }
 
 const (

--- a/swagger_models/variable_group_variable.go
+++ b/swagger_models/variable_group_variable.go
@@ -107,6 +107,8 @@ func (m *VariableGroupVariable) validateEncode(formats strfmt.Registry) error {
 		if err := m.Encode.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("encode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("encode")
 			}
 			return err
 		}
@@ -129,6 +131,8 @@ func (m *VariableGroupVariable) validateFormat(formats strfmt.Registry) error {
 		if err := m.Format.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("format")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("format")
 			}
 			return err
 		}
@@ -169,6 +173,8 @@ func (m *VariableGroupVariable) validateOptions(formats strfmt.Registry) error {
 			if err := m.Options[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("options" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("options" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -216,6 +222,8 @@ func (m *VariableGroupVariable) contextValidateEncode(ctx context.Context, forma
 		if err := m.Encode.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("encode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("encode")
 			}
 			return err
 		}
@@ -230,6 +238,8 @@ func (m *VariableGroupVariable) contextValidateFormat(ctx context.Context, forma
 		if err := m.Format.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("format")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("format")
 			}
 			return err
 		}
@@ -246,6 +256,8 @@ func (m *VariableGroupVariable) contextValidateOptions(ctx context.Context, form
 			if err := m.Options[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("options" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("options" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/variable_variable_format.go
+++ b/swagger_models/variable_variable_format.go
@@ -31,8 +31,12 @@ import (
 type VariableVariableFormat string
 
 func NewVariableVariableFormat(value VariableVariableFormat) *VariableVariableFormat {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated VariableVariableFormat.
+func (m VariableVariableFormat) Pointer() *VariableVariableFormat {
+	return &m
 }
 
 const (

--- a/swagger_models/vm.go
+++ b/swagger_models/vm.go
@@ -103,6 +103,8 @@ func (m *VM) validateMode(formats strfmt.Registry) error {
 		if err := m.Mode.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("mode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("mode")
 			}
 			return err
 		}
@@ -144,6 +146,8 @@ func (m *VM) contextValidateMode(ctx context.Context, formats strfmt.Registry) e
 		if err := m.Mode.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("mode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("mode")
 			}
 			return err
 		}

--- a/swagger_models/vm_manifest.go
+++ b/swagger_models/vm_manifest.go
@@ -167,6 +167,8 @@ func (m *VMManifest) validateAppType(formats strfmt.Registry) error {
 		if err := m.AppType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -184,6 +186,8 @@ func (m *VMManifest) validateConfiguration(formats strfmt.Registry) error {
 		if err := m.Configuration.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("configuration")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("configuration")
 			}
 			return err
 		}
@@ -201,6 +205,8 @@ func (m *VMManifest) validateContainerDetail(formats strfmt.Registry) error {
 		if err := m.ContainerDetail.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("containerDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("containerDetail")
 			}
 			return err
 		}
@@ -218,6 +224,8 @@ func (m *VMManifest) validateDeploymentType(formats strfmt.Registry) error {
 		if err := m.DeploymentType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}
@@ -235,6 +243,8 @@ func (m *VMManifest) validateDesc(formats strfmt.Registry) error {
 		if err := m.Desc.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("desc")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("desc")
 			}
 			return err
 		}
@@ -269,6 +279,8 @@ func (m *VMManifest) validateImages(formats strfmt.Registry) error {
 			if err := m.Images[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("images" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("images" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -293,6 +305,8 @@ func (m *VMManifest) validateInterfaces(formats strfmt.Registry) error {
 			if err := m.Interfaces[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("interfaces" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("interfaces" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -312,6 +326,8 @@ func (m *VMManifest) validateModule(formats strfmt.Registry) error {
 		if err := m.Module.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("module")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("module")
 			}
 			return err
 		}
@@ -329,6 +345,8 @@ func (m *VMManifest) validateOwner(formats strfmt.Registry) error {
 		if err := m.Owner.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("owner")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("owner")
 			}
 			return err
 		}
@@ -351,6 +369,8 @@ func (m *VMManifest) validateResources(formats strfmt.Registry) error {
 			if err := m.Resources[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("resources" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("resources" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -417,6 +437,8 @@ func (m *VMManifest) contextValidateAppType(ctx context.Context, formats strfmt.
 		if err := m.AppType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -431,6 +453,8 @@ func (m *VMManifest) contextValidateConfiguration(ctx context.Context, formats s
 		if err := m.Configuration.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("configuration")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("configuration")
 			}
 			return err
 		}
@@ -445,6 +469,8 @@ func (m *VMManifest) contextValidateContainerDetail(ctx context.Context, formats
 		if err := m.ContainerDetail.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("containerDetail")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("containerDetail")
 			}
 			return err
 		}
@@ -459,6 +485,8 @@ func (m *VMManifest) contextValidateDeploymentType(ctx context.Context, formats 
 		if err := m.DeploymentType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}
@@ -473,6 +501,8 @@ func (m *VMManifest) contextValidateDesc(ctx context.Context, formats strfmt.Reg
 		if err := m.Desc.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("desc")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("desc")
 			}
 			return err
 		}
@@ -489,6 +519,8 @@ func (m *VMManifest) contextValidateImages(ctx context.Context, formats strfmt.R
 			if err := m.Images[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("images" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("images" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -507,6 +539,8 @@ func (m *VMManifest) contextValidateInterfaces(ctx context.Context, formats strf
 			if err := m.Interfaces[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("interfaces" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("interfaces" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -523,6 +557,8 @@ func (m *VMManifest) contextValidateModule(ctx context.Context, formats strfmt.R
 		if err := m.Module.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("module")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("module")
 			}
 			return err
 		}
@@ -537,6 +573,8 @@ func (m *VMManifest) contextValidateOwner(ctx context.Context, formats strfmt.Re
 		if err := m.Owner.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("owner")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("owner")
 			}
 			return err
 		}
@@ -553,6 +591,8 @@ func (m *VMManifest) contextValidateResources(ctx context.Context, formats strfm
 			if err := m.Resources[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("resources" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("resources" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/vm_manifest_image.go
+++ b/swagger_models/vm_manifest_image.go
@@ -88,6 +88,8 @@ func (m *VMManifestImage) validateParams(formats strfmt.Registry) error {
 			if err := m.Params[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("params" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("params" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -120,6 +122,8 @@ func (m *VMManifestImage) contextValidateParams(ctx context.Context, formats str
 			if err := m.Params[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("params" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("params" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/swagger_models/vm_manifest_summary.go
+++ b/swagger_models/vm_manifest_summary.go
@@ -102,6 +102,8 @@ func (m *VMManifestSummary) validateAppType(formats strfmt.Registry) error {
 		if err := m.AppType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -119,6 +121,8 @@ func (m *VMManifestSummary) validateDeploymentType(formats strfmt.Registry) erro
 		if err := m.DeploymentType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}
@@ -136,6 +140,8 @@ func (m *VMManifestSummary) validateDesc(formats strfmt.Registry) error {
 		if err := m.Desc.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("desc")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("desc")
 			}
 			return err
 		}
@@ -165,6 +171,8 @@ func (m *VMManifestSummary) validateModule(formats strfmt.Registry) error {
 		if err := m.Module.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("module")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("module")
 			}
 			return err
 		}
@@ -205,6 +213,8 @@ func (m *VMManifestSummary) contextValidateAppType(ctx context.Context, formats 
 		if err := m.AppType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("appType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("appType")
 			}
 			return err
 		}
@@ -219,6 +229,8 @@ func (m *VMManifestSummary) contextValidateDeploymentType(ctx context.Context, f
 		if err := m.DeploymentType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deploymentType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deploymentType")
 			}
 			return err
 		}
@@ -233,6 +245,8 @@ func (m *VMManifestSummary) contextValidateDesc(ctx context.Context, formats str
 		if err := m.Desc.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("desc")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("desc")
 			}
 			return err
 		}
@@ -247,6 +261,8 @@ func (m *VMManifestSummary) contextValidateModule(ctx context.Context, formats s
 		if err := m.Module.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("module")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("module")
 			}
 			return err
 		}

--- a/swagger_models/vol_inst_config.go
+++ b/swagger_models/vol_inst_config.go
@@ -108,6 +108,8 @@ func (m *VolInstConfig) validateAccessmode(formats strfmt.Registry) error {
 		if err := m.Accessmode.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("accessmode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("accessmode")
 			}
 			return err
 		}
@@ -125,6 +127,8 @@ func (m *VolInstConfig) validatePurge(formats strfmt.Registry) error {
 		if err := m.Purge.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("purge")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("purge")
 			}
 			return err
 		}
@@ -142,6 +146,8 @@ func (m *VolInstConfig) validateRevision(formats strfmt.Registry) error {
 		if err := m.Revision.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -159,6 +165,8 @@ func (m *VolInstConfig) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -199,6 +207,8 @@ func (m *VolInstConfig) contextValidateAccessmode(ctx context.Context, formats s
 		if err := m.Accessmode.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("accessmode")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("accessmode")
 			}
 			return err
 		}
@@ -213,6 +223,8 @@ func (m *VolInstConfig) contextValidatePurge(ctx context.Context, formats strfmt
 		if err := m.Purge.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("purge")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("purge")
 			}
 			return err
 		}
@@ -227,6 +239,8 @@ func (m *VolInstConfig) contextValidateRevision(ctx context.Context, formats str
 		if err := m.Revision.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("revision")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("revision")
 			}
 			return err
 		}
@@ -241,6 +255,8 @@ func (m *VolInstConfig) contextValidateType(ctx context.Context, formats strfmt.
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/vol_inst_filter.go
+++ b/swagger_models/vol_inst_filter.go
@@ -60,6 +60,8 @@ func (m *VolInstFilter) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -88,6 +90,8 @@ func (m *VolInstFilter) contextValidateType(ctx context.Context, formats strfmt.
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/vol_inst_list.go
+++ b/swagger_models/vol_inst_list.go
@@ -68,6 +68,8 @@ func (m *VolInstList) validateCfgList(formats strfmt.Registry) error {
 			if err := m.CfgList[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("cfgList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cfgList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -92,6 +94,8 @@ func (m *VolInstList) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -111,6 +115,8 @@ func (m *VolInstList) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -149,6 +155,8 @@ func (m *VolInstList) contextValidateCfgList(ctx context.Context, formats strfmt
 			if err := m.CfgList[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("cfgList" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cfgList" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -167,6 +175,8 @@ func (m *VolInstList) contextValidateList(ctx context.Context, formats strfmt.Re
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -183,6 +193,8 @@ func (m *VolInstList) contextValidateNext(ctx context.Context, formats strfmt.Re
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}

--- a/swagger_models/vol_inst_short_config.go
+++ b/swagger_models/vol_inst_short_config.go
@@ -60,6 +60,8 @@ func (m *VolInstShortConfig) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -88,6 +90,8 @@ func (m *VolInstShortConfig) contextValidateType(ctx context.Context, formats st
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/vol_inst_status_filter.go
+++ b/swagger_models/vol_inst_status_filter.go
@@ -67,6 +67,8 @@ func (m *VolInstStatusFilter) validateRunState(formats strfmt.Registry) error {
 		if err := m.RunState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -84,6 +86,8 @@ func (m *VolInstStatusFilter) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -116,6 +120,8 @@ func (m *VolInstStatusFilter) contextValidateRunState(ctx context.Context, forma
 		if err := m.RunState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -130,6 +136,8 @@ func (m *VolInstStatusFilter) contextValidateType(ctx context.Context, formats s
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/vol_inst_status_list_msg.go
+++ b/swagger_models/vol_inst_status_list_msg.go
@@ -78,6 +78,8 @@ func (m *VolInstStatusListMsg) validateList(formats strfmt.Registry) error {
 			if err := m.List[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -97,6 +99,8 @@ func (m *VolInstStatusListMsg) validateNext(formats strfmt.Registry) error {
 		if err := m.Next.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -114,6 +118,8 @@ func (m *VolInstStatusListMsg) validateSummaryByState(formats strfmt.Registry) e
 		if err := m.SummaryByState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -131,6 +137,8 @@ func (m *VolInstStatusListMsg) validateSummaryByType(formats strfmt.Registry) er
 		if err := m.SummaryByType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByType")
 			}
 			return err
 		}
@@ -173,6 +181,8 @@ func (m *VolInstStatusListMsg) contextValidateList(ctx context.Context, formats 
 			if err := m.List[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("list" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("list" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -189,6 +199,8 @@ func (m *VolInstStatusListMsg) contextValidateNext(ctx context.Context, formats 
 		if err := m.Next.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("next")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("next")
 			}
 			return err
 		}
@@ -203,6 +215,8 @@ func (m *VolInstStatusListMsg) contextValidateSummaryByState(ctx context.Context
 		if err := m.SummaryByState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByState")
 			}
 			return err
 		}
@@ -217,6 +231,8 @@ func (m *VolInstStatusListMsg) contextValidateSummaryByType(ctx context.Context,
 		if err := m.SummaryByType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("summaryByType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("summaryByType")
 			}
 			return err
 		}

--- a/swagger_models/vol_inst_status_msg.go
+++ b/swagger_models/vol_inst_status_msg.go
@@ -117,6 +117,8 @@ func (m *VolInstStatusMsg) validateBlobs(formats strfmt.Registry) error {
 			if err := m.Blobs[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("blobs" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("blobs" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -136,6 +138,8 @@ func (m *VolInstStatusMsg) validateDeviceState(formats strfmt.Registry) error {
 		if err := m.DeviceState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deviceState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deviceState")
 			}
 			return err
 		}
@@ -158,6 +162,8 @@ func (m *VolInstStatusMsg) validateErrInfo(formats strfmt.Registry) error {
 			if err := m.ErrInfo[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("errInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("errInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -177,6 +183,8 @@ func (m *VolInstStatusMsg) validateResource(formats strfmt.Registry) error {
 		if err := m.Resource.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("resource")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("resource")
 			}
 			return err
 		}
@@ -194,6 +202,8 @@ func (m *VolInstStatusMsg) validateRunState(formats strfmt.Registry) error {
 		if err := m.RunState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -211,6 +221,8 @@ func (m *VolInstStatusMsg) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -228,6 +240,8 @@ func (m *VolInstStatusMsg) validateUsage(formats strfmt.Registry) error {
 		if err := m.Usage.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("usage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("usage")
 			}
 			return err
 		}
@@ -282,6 +296,8 @@ func (m *VolInstStatusMsg) contextValidateBlobs(ctx context.Context, formats str
 			if err := m.Blobs[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("blobs" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("blobs" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -298,6 +314,8 @@ func (m *VolInstStatusMsg) contextValidateDeviceState(ctx context.Context, forma
 		if err := m.DeviceState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deviceState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deviceState")
 			}
 			return err
 		}
@@ -314,6 +332,8 @@ func (m *VolInstStatusMsg) contextValidateErrInfo(ctx context.Context, formats s
 			if err := m.ErrInfo[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("errInfo" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("errInfo" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -330,6 +350,8 @@ func (m *VolInstStatusMsg) contextValidateResource(ctx context.Context, formats 
 		if err := m.Resource.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("resource")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("resource")
 			}
 			return err
 		}
@@ -344,6 +366,8 @@ func (m *VolInstStatusMsg) contextValidateRunState(ctx context.Context, formats 
 		if err := m.RunState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -358,6 +382,8 @@ func (m *VolInstStatusMsg) contextValidateType(ctx context.Context, formats strf
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -372,6 +398,8 @@ func (m *VolInstStatusMsg) contextValidateUsage(ctx context.Context, formats str
 		if err := m.Usage.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("usage")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("usage")
 			}
 			return err
 		}

--- a/swagger_models/vol_inst_status_summary_msg.go
+++ b/swagger_models/vol_inst_status_summary_msg.go
@@ -98,6 +98,8 @@ func (m *VolInstStatusSummaryMsg) validateDeviceState(formats strfmt.Registry) e
 		if err := m.DeviceState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deviceState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deviceState")
 			}
 			return err
 		}
@@ -115,6 +117,8 @@ func (m *VolInstStatusSummaryMsg) validateRunState(formats strfmt.Registry) erro
 		if err := m.RunState.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -132,6 +136,8 @@ func (m *VolInstStatusSummaryMsg) validateType(formats strfmt.Registry) error {
 		if err := m.Type.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}
@@ -168,6 +174,8 @@ func (m *VolInstStatusSummaryMsg) contextValidateDeviceState(ctx context.Context
 		if err := m.DeviceState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deviceState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deviceState")
 			}
 			return err
 		}
@@ -182,6 +190,8 @@ func (m *VolInstStatusSummaryMsg) contextValidateRunState(ctx context.Context, f
 		if err := m.RunState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runState")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("runState")
 			}
 			return err
 		}
@@ -196,6 +206,8 @@ func (m *VolInstStatusSummaryMsg) contextValidateType(ctx context.Context, forma
 		if err := m.Type.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("type")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("type")
 			}
 			return err
 		}

--- a/swagger_models/volume_instance_access_mode.go
+++ b/swagger_models/volume_instance_access_mode.go
@@ -23,8 +23,12 @@ import (
 type VolumeInstanceAccessMode string
 
 func NewVolumeInstanceAccessMode(value VolumeInstanceAccessMode) *VolumeInstanceAccessMode {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated VolumeInstanceAccessMode.
+func (m VolumeInstanceAccessMode) Pointer() *VolumeInstanceAccessMode {
+	return &m
 }
 
 const (

--- a/swagger_models/volume_instance_type.go
+++ b/swagger_models/volume_instance_type.go
@@ -23,8 +23,12 @@ import (
 type VolumeInstanceType string
 
 func NewVolumeInstanceType(value VolumeInstanceType) *VolumeInstanceType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated VolumeInstanceType.
+func (m VolumeInstanceType) Pointer() *VolumeInstanceType {
+	return &m
 }
 
 const (

--- a/swagger_models/z_manufacturer_info.go
+++ b/swagger_models/z_manufacturer_info.go
@@ -81,6 +81,8 @@ func (m *ZManufacturerInfo) validateHSMStatus(formats strfmt.Registry) error {
 		if err := m.HSMStatus.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("hSMStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("hSMStatus")
 			}
 			return err
 		}
@@ -109,6 +111,8 @@ func (m *ZManufacturerInfo) contextValidateHSMStatus(ctx context.Context, format
 		if err := m.HSMStatus.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("hSMStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("hSMStatus")
 			}
 			return err
 		}

--- a/swagger_models/zc_ops_status.go
+++ b/swagger_models/zc_ops_status.go
@@ -27,8 +27,12 @@ import (
 type ZcOpsStatus string
 
 func NewZcOpsStatus(value ZcOpsStatus) *ZcOpsStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ZcOpsStatus.
+func (m ZcOpsStatus) Pointer() *ZcOpsStatus {
+	return &m
 }
 
 const (

--- a/swagger_models/zc_ops_type.go
+++ b/swagger_models/zc_ops_type.go
@@ -23,8 +23,12 @@ import (
 type ZcOpsType string
 
 func NewZcOpsType(value ZcOpsType) *ZcOpsType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ZcOpsType.
+func (m ZcOpsType) Pointer() *ZcOpsType {
+	return &m
 }
 
 const (

--- a/swagger_models/zsrv_error.go
+++ b/swagger_models/zsrv_error.go
@@ -55,6 +55,8 @@ func (m *ZsrvError) validateEc(formats strfmt.Registry) error {
 		if err := m.Ec.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ec")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ec")
 			}
 			return err
 		}
@@ -83,6 +85,8 @@ func (m *ZsrvError) contextValidateEc(ctx context.Context, formats strfmt.Regist
 		if err := m.Ec.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ec")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ec")
 			}
 			return err
 		}

--- a/swagger_models/zsrv_error_code.go
+++ b/swagger_models/zsrv_error_code.go
@@ -31,8 +31,12 @@ import (
 type ZsrvErrorCode string
 
 func NewZsrvErrorCode(value ZsrvErrorCode) *ZsrvErrorCode {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ZsrvErrorCode.
+func (m ZsrvErrorCode) Pointer() *ZsrvErrorCode {
+	return &m
 }
 
 const (

--- a/swagger_models/zsrv_response.go
+++ b/swagger_models/zsrv_response.go
@@ -108,6 +108,8 @@ func (m *ZsrvResponse) validateError(formats strfmt.Registry) error {
 			if err := m.Error[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("error" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("error" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -127,6 +129,8 @@ func (m *ZsrvResponse) validateObjectType(formats strfmt.Registry) error {
 		if err := m.ObjectType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("objectType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("objectType")
 			}
 			return err
 		}
@@ -144,6 +148,8 @@ func (m *ZsrvResponse) validateOperationStatus(formats strfmt.Registry) error {
 		if err := m.OperationStatus.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("operationStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("operationStatus")
 			}
 			return err
 		}
@@ -161,6 +167,8 @@ func (m *ZsrvResponse) validateOperationType(formats strfmt.Registry) error {
 		if err := m.OperationType.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("operationType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("operationType")
 			}
 			return err
 		}
@@ -203,6 +211,8 @@ func (m *ZsrvResponse) contextValidateError(ctx context.Context, formats strfmt.
 			if err := m.Error[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("error" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("error" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -219,6 +229,8 @@ func (m *ZsrvResponse) contextValidateObjectType(ctx context.Context, formats st
 		if err := m.ObjectType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("objectType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("objectType")
 			}
 			return err
 		}
@@ -233,6 +245,8 @@ func (m *ZsrvResponse) contextValidateOperationStatus(ctx context.Context, forma
 		if err := m.OperationStatus.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("operationStatus")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("operationStatus")
 			}
 			return err
 		}
@@ -247,6 +261,8 @@ func (m *ZsrvResponse) contextValidateOperationType(ctx context.Context, formats
 		if err := m.OperationType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("operationType")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("operationType")
 			}
 			return err
 		}


### PR DESCRIPTION
1) Fix UrlForObjectRequest to handle all action types ( activate,
    inactivate,publish, status etc ) generically

2) Updated swagger models to latest ZEDCloud API