### PR TITLE
Fix client.GetObj to return http.response to allow callers to handle the case of object not found.

### DIFF
--- a/client.go
+++ b/client.go
@@ -97,6 +97,13 @@ func isHttpStatusCodeSuccess(statusCode int32) bool {
 	return false
 }
 
+func IsObjectNotFound(resp *http.Response) bool {
+    if resp != nil && int32(resp.StatusCode) == http.StatusNotFound {
+        return true
+    }
+    return false
+}
+
 func (client *Client) createRequest(method, urlExtension string,
 	data interface{}) (*http.Request, error) {
 	url := client.BaseUrl + urlExtension
@@ -295,23 +302,23 @@ func (client *Client) DeleteObj(typeUrl, id string) (
 //      client.GetObj("devices", "testDevice", "", false, rspData)
 func (client *Client) GetObj(typeUrl, name, id string,
 	status bool,
-	rspBody interface{}) error {
+	rspBody interface{}) (*http.Response, error) {
 
 	if client == nil {
-		return fmt.Errorf("client.GetObj - nil client")
+		return nil, fmt.Errorf("client.GetObj - nil client")
 	}
 
 	url, err := UrlForNameOrId(name, id)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	url = typeUrl + "/" + url
 	if status {
 		url += "/status"
 	}
 	client.XRequestIdPrefix = "TF-GetObj"
-	_, err = client.SendReq("GET", url, nil, rspBody)
-	return err
+	resp, err := client.SendReq("GET", url, nil, rspBody)
+	return resp, err
 }
 
 func sanitizeZedcloudUrl(zedcloudUrl string) string {

--- a/zedcloud_client/appinst.go
+++ b/zedcloud_client/appinst.go
@@ -15,7 +15,7 @@ func getAppInstConfig(client *zedcloudapi.Client,
 	fmt.Printf("\nSending GET AppInst Config Request\n")
 	client.XRequestIdPrefix = "zedcloudapi-client-get-appinst"
 	rspData := &swagger_models.AppInstance{}
-	err := client.GetObj("apps/instances", name, id, false, rspData)
+	_, err := client.GetObj("apps/instances", name, id, false, rspData)
 	if err != nil {
 		fmt.Printf("Failed to get AppInst. err: %+v", err)
 		return nil, err

--- a/zedcloud_client/edgeapp.go
+++ b/zedcloud_client/edgeapp.go
@@ -14,7 +14,7 @@ func getEdgeAppConfig(client *zedcloudapi.Client,
 	name, id string) (*swagger_models.AppConfig, error) {
 	fmt.Printf("\nSending getEdgeAppConfig Request\n")
 	rspData := &swagger_models.AppConfig{}
-	err := client.GetObj("apps", name, id, false, rspData)
+	_, err := client.GetObj("apps", name, id, false, rspData)
 	if err != nil {
 		return nil, err
 	}

--- a/zedcloud_client/edgenode.go
+++ b/zedcloud_client/edgenode.go
@@ -22,7 +22,7 @@ func setDeviceTitle(client *zedcloudapi.Client, devCfg *swagger_models.DeviceCon
 func getEdgeNodeConfig(client *zedcloudapi.Client, name, id string) *swagger_models.DeviceConfig {
 	fmt.Printf("\nSending GetDevice Request\n")
 	rspData := &swagger_models.DeviceConfig{}
-	err := client.GetObj("devices", name, id, false, rspData)
+	_, err := client.GetObj("devices", name, id, false, rspData)
 	if err != nil {
 		return rspData
 	}

--- a/zedcloud_client/netinst.go
+++ b/zedcloud_client/netinst.go
@@ -15,7 +15,7 @@ func getNetInstConfig(client *zedcloudapi.Client,
 	fmt.Printf("\nSending GET NetInst Config Request\n")
 	client.XRequestIdPrefix = "zedcloudapi-client-get-nwinst"
 	rspData := &swagger_models.NetInstConfig{}
-	err := client.GetObj("netinsts", name, id, false, rspData)
+	_, err := client.GetObj("netinsts", name, id, false, rspData)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix client.GetObj to return http.response to allow callers to handle the case of object not found.